### PR TITLE
docs: add CLAUDE.md pointing to AGENTS.md as single source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# NutriAI — Claude Code Context
+
+> **Single source of truth: `AGENTS.md`** — All project context, conventions, architecture, CI/CD, and development workflow are documented there. Read it fully before starting work.
+
+## Rules
+
+1. **Always read `AGENTS.md` first** — it contains the Quick Reference, conventions, architecture patterns, and workflow.
+2. **When updating documentation, update `AGENTS.md`** — not this file. This file is only a pointer.
+3. **Follow the conventions in `AGENTS.md`** — naming, architecture, auth patterns, tenant isolation, etc.
+4. **Never commit secrets** — see the Secrets table in `AGENTS.md`.
+5. **PR workflow** — branch from `main`, open PR, wait for CI + AI review, merge. See Development Workflow in `AGENTS.md`.


### PR DESCRIPTION
CLAUDE.md is the entry point for Claude Code agents. It references AGENTS.md as the single source of truth and instructs agents to always update AGENTS.md (not CLAUDE.md) when modifying docs.