### PR TITLE
chore(ci): catalog reviewer false positives and add PR sizing guideline

### DIFF
--- a/.github/review-rules.md
+++ b/.github/review-rules.md
@@ -51,3 +51,19 @@
 - Existing ESLint/Checkstyle warnings that are already tracked (complexity, max-lines)
 - Test-only helpers or fixtures
 - Files, endpoints, or code NOT present in the diff — only flag what is VISIBLE in the diff
+
+## Known False Positives (project-specific non-issues)
+
+These patterns have surfaced as findings in past reviews but are intentional / safe in this stack. Do NOT raise them again.
+
+### JSON null vs undefined in optional fields
+The frontend may send `null` for some optional numeric fields and omit others (`undefined` → JSON.stringify drops the key). This is NOT a contract inconsistency: Spring/Jackson treat JSON `null` and an absent key as **equivalent** for optional boxed fields (`Integer`, `BigDecimal`, `String`, lists) when there is no `@NotNull` annotation differentiating them. The backend deserializes both cases identically. Do not flag this as an API contract problem.
+
+### Spring constructor injection
+Adding a new repository/service parameter to a Spring `@Service` / `@Component` constructor does NOT require additional bean configuration. Spring auto-wires by type; if the dependency is itself a Spring-managed bean, it is injected automatically. Do not flag "may fail at startup with NoSuchBeanDefinitionException" for plain constructor parameter additions.
+
+### JpaRepository inherited methods
+Spring Data `JpaRepository` interfaces inherit `findAll`, `findById`, `deleteById`, etc. without an explicit `nutritionistId` filter. The project relies on the **service layer** to scope these calls (e.g., always preceded by an ownership check). Do not flag inherited methods as "tenant isolation violation" — flag only when a service method directly calls `findById` or similar without a prior nutritionistId check on the parent entity.
+
+### Test-only repository methods
+`*RepositoryTest` classes use bare repository methods (no nutritionistId scoping) for setup/cleanup. These are integration tests against a sandboxed DB; service-layer scoping rules do not apply. Do not flag tenant-isolation issues in `*RepositoryTest` files.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -12,6 +12,12 @@ name: AI Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    # Doc-only / planning-only changes nao precisam consumir quota Ollama nem
+    # disparar stale-dismiss em approves anteriores.
+    paths-ignore:
+      - '**/*.md'
+      - '.planning/**'
+      - 'docs/**'
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}
@@ -69,6 +75,14 @@ jobs:
         run: |
           git diff --name-only origin/${{ github.base_ref }}...HEAD > /tmp/pr_files.txt
           echo "Manifest size: $(wc -l < /tmp/pr_files.txt) files"
+
+      - name: Warn on large PR
+        if: steps.diff.outputs.lines > 2500
+        shell: bash
+        env:
+          LINES: ${{ steps.diff.outputs.lines }}
+        run: |
+          echo "::warning title=Large PR::Este PR tem ${LINES} linhas de diff. PRs grandes amplificam falsos positivos do reviewer LLM (mais chunks = mais alucinacoes acumuladas) e cansam o review humano. Considere dividir em PRs menores. Ver AGENTS.md > 'PR sizing convention'."
 
       - name: Load project rules
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,25 +20,41 @@
 2. **Make changes** following conventions in this file
 3. **Verify locally**: `npx tsc --noEmit` (frontend), `./gradlew compileJava` (backend)
 4. **Push and open PR** against `main`
-5. **CI runs automatically**: frontend-ci, backend-ci (path-filtered), ai-review (always)
-6. **AI reviewer** always posts a review — APPROVE or REQUEST_CHANGES
+5. **CI runs automatically**: frontend-ci, backend-ci (path-filtered), ai-review (skipped on doc-only PRs)
+6. **AI reviewer** posts a review — APPROVE or REQUEST_CHANGES
 7. **If REQUEST_CHANGES**: address findings, push, AI re-reviews
-8. **Merge** when all required checks pass + required approvals:
-   - **Internal PRs** (owner/collab): 2 approvals, but owner can merge with `--admin` bypass
-   - **External PRs** (third-party): 2 approvals required — AI (1st) + human maintainer (2nd)
+8. **Merge** when all required checks pass + 1 approval (AI counts):
+   - **Internal PRs**: AI approval is enough; owner is admin and can bypass if needed.
+   - **External PRs**: AI approval + manual approval from owner (convention, not technically enforced).
+
+### PR sizing convention (soft limit ~2.000 linhas de diff)
+
+PRs gigantes (8k+ linhas, fase inteira) **amplificam falsos positivos do reviewer LLM**:
+- Mais chunks = mais chamadas LLM = chance multiplicativa de pelo menos um chunk alucinar.
+- Findings acumulam: 3/chunk × 8 chunks ≈ ~24 candidatos, e a maioria sao especulacoes.
+- Self-critique recebe diff maior, fica perto do timeout, qualidade da validacao cai.
+- O reviewer humano tambem revisa pior um PR de 8k linhas que tres de 2k.
+
+Diretrizes:
+- **Alvo: <2.000 linhas** de diff por PR (warning automatico no `ai-review.yml` quando passar de 2.500).
+- **Slice vertical**: prefira `Dashboard backend` + `Dashboard frontend` + `Biometry backend` + ... ao inves de `Phase 06 inteira`.
+- **Stacked PRs**: branch base intermediaria (ex.: `feat/06-dashboard-biometry`) recebe PRs pequenos das sub-features; quando completa, vai pra `main` em um PR final.
+- **Quando flexibilizar** (passar do limite e' aceitavel): migrations grandes (V13 com 5 tabelas), refactors mecanicos (rename em massa), bumps de dependencia.
+- **Doc-only / planning-only** PRs nao disparam o reviewer (paths-ignore em `*.md`, `.planning/**`, `docs/**`).
 
 ### Required Checks on `main`
 
-- `ai-review` — always required
+- `ai-review` — required (mas pulado em PRs doc-only via `paths-ignore`)
 - `frontend` — required when `frontend/**` or `.github/workflows/frontend-ci.yml` changed
 - `backend` — required when `backend/**` or `.github/workflows/backend-ci.yml` changed
 - `e2e` — runs conditionally, not required for merge
 
 ### Branch Protection
 
-- enforce_admins: **false** (owner can bypass 2-approval rule with `--admin`)
-- 2 approvals required (AI approval counts as 1)
-- Dismiss stale reviews: yes
+- enforce_admins: **false** (owner pode mergear via "Merge anyway" mesmo sem approves)
+- 1 approval required (AI approval counts)
+- require_code_owner_reviews: false
+- Dismiss stale reviews: yes (pushes invalidam approves anteriores)
 
 ## Secrets (never commit these)
 


### PR DESCRIPTION
## Summary

- Cataloga 4 falsos positivos recorrentes em `.github/review-rules.md` (carregados no system prompt do reviewer) — lista deve crescer conforme aparecerem novos.
- `paths-ignore` no workflow `ai-review.yml` pra `*.md`, `.planning/**`, `docs/**` — PRs doc-only nao gastam ~10min de quota nem stale-dismissam approves.
- Warning automatico (nao bloqueante) quando PR tem >2.500 linhas de diff, com link pra guideline.
- Seção "PR sizing convention" em `AGENTS.md > Development Workflow` documentando o alvo de <2k linhas, estrategias de split (slice vertical, stacked PRs) e quando flexibilizar.
- Atualiza secao "Branch Protection" em AGENTS.md pra refletir a config atual (1 approval, sem code_owner_reviews).

## Why

PR 28 (Phase 06 inteira, ~8k linhas) precisou de **20+ runs do reviewer** porque cada run achava 1-3 falsos positivos diferentes (alucinacoes do LLM em chunks isolados). Causa raiz: PRs grandes amplificam falsos positivos por mais chunks = mais chance multiplicativa de alucinacao em pelo menos um.

Esta PR consolida os aprendizados:
1. Documenta os falsos positivos especificos do projeto pra o reviewer evitar repeti-los.
2. Estabelece convencao de tamanho pra reduzir o problema na origem.
3. Para de gastar quota com PRs que nao tem codigo (doc/planning).

## Test plan

- [ ] CI runs `frontend-ci`, `backend-ci`, `ai-review` (sem skip — esta PR mexe em `.yml`, nao em `.md` apenas)
- [ ] Verificar que warning step aparece se simular PR > 2500 linhas
- [ ] Verificar que reviewer aprova (PR pequeno, ~60 linhas, baixissima chance de falso positivo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)