### PR TITLE
feat(frontend): padronizar validacao por campo com useValidation hook (LUC-37)

### DIFF
--- a/frontend/e2e/food-catalog.spec.ts
+++ b/frontend/e2e/food-catalog.spec.ts
@@ -98,15 +98,35 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-07: Create food with invalid unit returns 400', async ({ request }) => {
     const response = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Test invalid unit', category: 'PROTEINA', unit: 'grama', referenceAmount: 100, kcal: 100, prot: 20, carb: 5, fat: 2 },
+      data: {
+        name: 'Test invalid unit',
+        category: 'PROTEINA',
+        unit: 'grama',
+        referenceAmount: 100,
+        kcal: 100,
+        prot: 20,
+        carb: 5,
+        fat: 2,
+      },
     });
     expect(response.status()).toBe(400);
   });
 
-  test('E2E-FC-08: Create food with pt-BR category label "Proteína" returns 400', async ({ request }) => {
+  test('E2E-FC-08: Create food with pt-BR category label "Proteína" returns 400', async ({
+    request,
+  }) => {
     const response = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Test pt-BR category', category: 'Proteína', unit: 'GRAMAS', referenceAmount: 100, kcal: 100, prot: 20, carb: 5, fat: 2 },
+      data: {
+        name: 'Test pt-BR category',
+        category: 'Proteína',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 100,
+        prot: 20,
+        carb: 5,
+        fat: 2,
+      },
     });
     expect(response.status()).toBe(400);
   });
@@ -114,7 +134,15 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-09: Create food without name returns 400', async ({ request }) => {
     const response = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { category: 'PROTEINA', unit: 'GRAMAS', referenceAmount: 100, kcal: 100, prot: 20, carb: 5, fat: 2 },
+      data: {
+        category: 'PROTEINA',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 100,
+        prot: 20,
+        carb: 5,
+        fat: 2,
+      },
     });
     expect(response.status()).toBe(400);
   });
@@ -130,7 +158,17 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-11: List foods returns paginated contract', async ({ request }) => {
     await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Listado E2E', category: 'PROTEINA', unit: 'GRAMAS', referenceAmount: 100, kcal: 100, prot: 20, carb: 5, fat: 2, fiber: 1 },
+      data: {
+        name: 'Listado E2E',
+        category: 'PROTEINA',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 100,
+        prot: 20,
+        carb: 5,
+        fat: 2,
+        fiber: 1,
+      },
     });
 
     const response = await request.get(`${API}/foods`, {
@@ -148,7 +186,17 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-12: Update food category succeeds', async ({ request }) => {
     const createResp = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Update E2E', category: 'CARBOIDRATO', unit: 'GRAMAS', referenceAmount: 100, kcal: 100, prot: 5, carb: 20, fat: 1, fiber: 2 },
+      data: {
+        name: 'Update E2E',
+        category: 'CARBOIDRATO',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 100,
+        prot: 5,
+        carb: 20,
+        fat: 1,
+        fiber: 2,
+      },
     });
     const created = await createResp.json();
     const foodId = created.data.id;
@@ -165,7 +213,17 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-13: Delete food via API', async ({ request }) => {
     const createResp = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Deletar E2E', category: 'GORDURA', unit: 'GRAMAS', referenceAmount: 100, kcal: 50, prot: 1, carb: 2, fat: 4, fiber: 0 },
+      data: {
+        name: 'Deletar E2E',
+        category: 'GORDURA',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 50,
+        prot: 1,
+        carb: 2,
+        fat: 4,
+        fiber: 0,
+      },
     });
     const created = await createResp.json();
     const foodId = created.data.id;
@@ -189,7 +247,16 @@ test.describe('Food Catalog — API Contract & Enum Validation', () => {
   test('E2E-FC-15: Get single food returns correct contract', async ({ request }) => {
     const createResp = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
-      data: { name: 'Single E2E', category: 'PROTEINA', unit: 'GRAMAS', referenceAmount: 100, kcal: 200, prot: 30, carb: 5, fat: 8 },
+      data: {
+        name: 'Single E2E',
+        category: 'PROTEINA',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: 200,
+        prot: 30,
+        carb: 5,
+        fat: 8,
+      },
     });
     const created = await createResp.json();
     const foodId = created.data.id;
@@ -222,16 +289,32 @@ test.describe('Food Catalog — UI→API Integration', () => {
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
     await page.evaluate((token) => {
-      localStorage.setItem('nutriai-auth', JSON.stringify({
-        state: { isAuthenticated: true, accessToken: token, user: { id: '1', name: 'Dra. Foods', email: 'f@test.com', role: 'NUTRITIONIST', onboardingCompleted: true } },
-        version: 0,
-      }));
+      localStorage.setItem(
+        'nutriai-auth',
+        JSON.stringify({
+          state: {
+            isAuthenticated: true,
+            accessToken: token,
+            user: {
+              id: '1',
+              name: 'Dra. Foods',
+              email: 'f@test.com',
+              role: 'NUTRITIONIST',
+              onboardingCompleted: true,
+            },
+          },
+          version: 0,
+        }),
+      );
     }, accessToken);
     await page.goto('/foods');
     await page.waitForLoadState('networkidle');
   });
 
-  test('E2E-FC-16: Create food via UI sends correct enum keys to API', async ({ page, request }) => {
+  test('E2E-FC-16: Create food via UI sends correct enum keys to API', async ({
+    page,
+    request,
+  }) => {
     await page.getByRole('button', { name: /novo alimento/i }).click();
     await page.waitForTimeout(500);
 
@@ -241,6 +324,9 @@ test.describe('Food Catalog — UI→API Integration', () => {
     const selects = page.locator('select');
     const categorySelect = selects.first();
     await categorySelect.selectOption({ label: 'Proteína' });
+
+    const refInput = page.locator('#create-food-ref');
+    await refInput.fill('100');
 
     const saveBtn = page.getByRole('button', { name: /salvar/i });
     await saveBtn.click();

--- a/frontend/src/components/patient/EditPatientModal.tsx
+++ b/frontend/src/components/patient/EditPatientModal.tsx
@@ -4,17 +4,14 @@ import { useToastStore } from '../../stores/toastStore';
 import type { Patient, ObjectiveOption } from '../../types/patient';
 import { OBJECTIVE_LABELS, OBJECTIVE_KEYS, REVERSE_OBJECTIVE_LABELS } from '../../types/patient';
 import { IconX, IconCheck } from '../icons';
-
-interface EditPatientModalProps {
-  patient: Patient;
-  onClose: () => void;
-}
+import { useValidation } from '../../hooks/useValidation';
 
 function formatPhone(value: string): string {
   const digits = value.replace(/\D/g, '');
   if (digits.length <= 2) return `(${digits}`;
   if (digits.length <= 7) return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
-  if (digits.length <= 11) return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+  if (digits.length <= 11)
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
   return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7, 11)}`;
 }
 
@@ -22,28 +19,81 @@ function stripPhone(value: string): string {
   return value.replace(/\D/g, '').slice(0, 11);
 }
 
+interface EditPatientModalProps {
+  patient: Patient;
+  onClose: () => void;
+}
+
 export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
   const updateMutation = useUpdatePatient();
-  const [name, setName] = useState(patient.name);
-  const [birthDate, setBirthDate] = useState(patient.birthDate ?? '');
   const [sex, setSex] = useState(patient.sex || 'F');
-  const [heightCm, setHeightCm] = useState(patient.heightCm != null ? String(patient.heightCm) : '');
-  const [whatsapp, setWhatsapp] = useState(formatPhone(patient.whatsapp ?? ''));
   const [objective, setObjective] = useState<ObjectiveOption>(
-    (REVERSE_OBJECTIVE_LABELS[patient.objective] ?? patient.objective) as ObjectiveOption
+    (REVERSE_OBJECTIVE_LABELS[patient.objective] ?? patient.objective) as ObjectiveOption,
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+  } = useValidation(
+    {
+      name: patient.name,
+      birthDate: patient.birthDate ?? '',
+      heightCm: patient.heightCm != null ? String(patient.heightCm) : '',
+      whatsapp: formatPhone(patient.whatsapp ?? ''),
+    } as Record<string, string>,
+    {
+      name: {
+        required: true,
+        requiredMessage: 'Nome é obrigatório.',
+        minLength: 2,
+        minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+      },
+      birthDate: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const d = new Date(v);
+          if (isNaN(d.getTime())) return 'Data inválida.';
+          if (d > new Date()) return 'Data não pode ser no futuro.';
+          return undefined;
+        },
+      },
+      heightCm: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Altura deve ser um número.';
+          if (n < 50 || n > 250) return 'Altura deve estar entre 50 e 250 cm.';
+          return undefined;
+        },
+      },
+      whatsapp: {
+        custom: (v) => {
+          const digits = stripPhone(v).replace(/\D/g, '');
+          if (!digits) return undefined;
+          if (digits.length < 10) return 'WhatsApp deve ter pelo menos 10 dígitos.';
+          if (digits.length > 11) return 'WhatsApp deve ter no máximo 11 dígitos.';
+          return undefined;
+        },
+      },
+    },
   );
 
-  const handle = () => {
-    if (!name.trim()) return;
+  const handleSave = () => {
+    if (!validateAll()) return;
+    setSubmitError(null);
     updateMutation.mutate(
       {
         id: patient.id,
         data: {
-          name: name.trim(),
-          ...(birthDate ? { birthDate } : {}),
+          name: form.name.trim(),
+          ...(form.birthDate ? { birthDate: form.birthDate } : {}),
           sex,
-          ...(heightCm ? { heightCm: Number(heightCm) } : {}),
-          ...(stripPhone(whatsapp) ? { whatsapp: stripPhone(whatsapp) } : {}),
+          ...(form.heightCm ? { heightCm: Number(form.heightCm) } : {}),
+          ...(stripPhone(form.whatsapp) ? { whatsapp: stripPhone(form.whatsapp) } : {}),
           objective,
         },
       },
@@ -52,42 +102,50 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
           useToastStore.getState().showSuccess('Paciente atualizado com sucesso');
           onClose();
         },
+        onError: (error) => {
+          setSubmitError(
+            error instanceof Error
+              ? error.message
+              : 'Não foi possível atualizar o paciente. Tente novamente.',
+          );
+        },
       },
     );
   };
 
-  const field = (label: string, val: string, set: (v: string) => void, opts: { type?: string; mono?: boolean; placeholder?: string } = {}) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-      <div className="eyebrow">{label}</div>
-      <input
-        value={val}
-        onChange={(e) => set(e.target.value)}
-        type={opts.type || 'text'}
-        placeholder={opts.placeholder || ''}
-        style={{
-          padding: '8px 10px',
-          border: '1px solid var(--border)',
-          borderRadius: 6,
-          fontSize: 13,
-          background: 'var(--surface)',
-          outline: 'none',
-          color: 'var(--fg)',
-          width: '100%',
-          boxSizing: 'border-box',
-          fontFamily: opts.mono ? 'var(--font-mono)' : 'var(--font-ui)',
-        }}
-        onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-        onBlur={(e) => (e.target.style.borderColor = 'var(--border)')}
-      />
-    </div>
-  );
+  const fieldStyle = (hasError: boolean): React.CSSProperties => ({
+    padding: '8px 10px',
+    border: `1px solid ${hasError ? 'var(--coral)' : 'var(--border)'}`,
+    borderRadius: 6,
+    fontSize: 13,
+    background: 'var(--surface)',
+    outline: 'none',
+    color: 'var(--fg)',
+    width: '100%',
+    boxSizing: 'border-box',
+    fontFamily: 'var(--font-ui)',
+  });
+
+  const canSubmit = form.name.trim().length >= 2 && !updateMutation.isPending;
 
   return (
     <div
-      style={{ position: 'fixed', inset: 0, background: 'rgba(11,12,10,0.4)', zIndex: 200, display: 'grid', placeItems: 'center', padding: 20 }}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(11,12,10,0.4)',
+        zIndex: 200,
+        display: 'grid',
+        placeItems: 'center',
+        padding: 20,
+      }}
       onClick={onClose}
     >
-      <div className="card" style={{ width: 'min(480px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }} onClick={(e) => e.stopPropagation()}>
+      <div
+        className="card"
+        style={{ width: 'min(480px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="card-h">
           <div className="title">Editar paciente</div>
           <div className="spacer" />
@@ -96,9 +154,48 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
           </button>
         </div>
         <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {field('Nome completo', name, setName, { placeholder: 'Ana Beatriz Lopes' })}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="edit-name">
+              Nome completo
+            </label>
+            <input
+              id="edit-name"
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              onBlur={onBlur('name')}
+              aria-invalid={errors.name ? 'true' : undefined}
+              aria-describedby={errors.name ? 'edit-name-error' : undefined}
+              placeholder="Ana Beatriz Lopes"
+              style={fieldStyle(!!errors.name)}
+            />
+            {errors.name && (
+              <p id="edit-name-error" className="text-xs text-coral" role="alert">
+                {errors.name}
+              </p>
+            )}
+          </div>
+
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-            {field('Data de nascimento', birthDate, setBirthDate, { type: 'date' })}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              <label className="eyebrow" htmlFor="edit-birthdate">
+                Data de nascimento
+              </label>
+              <input
+                id="edit-birthdate"
+                type="date"
+                value={form.birthDate}
+                onChange={(e) => set('birthDate', e.target.value)}
+                onBlur={onBlur('birthDate')}
+                aria-invalid={errors.birthDate ? 'true' : undefined}
+                aria-describedby={errors.birthDate ? 'edit-birthdate-error' : undefined}
+                style={fieldStyle(!!errors.birthDate)}
+              />
+              {errors.birthDate && (
+                <p id="edit-birthdate-error" className="text-xs text-coral" role="alert">
+                  {errors.birthDate}
+                </p>
+              )}
+            </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
               <div className="eyebrow">Sexo</div>
               <div className="seg" style={{ height: 36 }}>
@@ -111,42 +208,92 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
               </div>
             </div>
           </div>
+
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-            {field('Altura (cm)', heightCm, setHeightCm, { type: 'number', mono: true, placeholder: '168' })}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">WhatsApp</div>
+              <label className="eyebrow" htmlFor="edit-height">
+                Altura (cm)
+              </label>
               <input
-                value={whatsapp}
-                onChange={(e) => setWhatsapp(formatPhone(stripPhone(e.target.value)))}
+                id="edit-height"
+                type="number"
+                value={form.heightCm}
+                onChange={(e) => set('heightCm', e.target.value)}
+                onBlur={onBlur('heightCm')}
+                aria-invalid={errors.heightCm ? 'true' : undefined}
+                aria-describedby={errors.heightCm ? 'edit-height-error' : undefined}
+                placeholder="168"
+                style={{ ...fieldStyle(!!errors.heightCm), fontFamily: 'var(--font-mono)' }}
+              />
+              {errors.heightCm && (
+                <p id="edit-height-error" className="text-xs text-coral" role="alert">
+                  {errors.heightCm}
+                </p>
+              )}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              <label className="eyebrow" htmlFor="edit-whatsapp">
+                WhatsApp
+              </label>
+              <input
+                id="edit-whatsapp"
+                value={form.whatsapp}
+                onChange={(e) => set('whatsapp', formatPhone(stripPhone(e.target.value)))}
+                onBlur={onBlur('whatsapp')}
                 type="tel"
                 placeholder="(11) 99999-9999"
-                style={{
-                  padding: '8px 10px',
-                  border: '1px solid var(--border)',
-                  borderRadius: 6,
-                  fontSize: 13,
-                  background: 'var(--surface)',
-                  outline: 'none',
-                  color: 'var(--fg)',
-                  width: '100%',
-                  boxSizing: 'border-box',
-                  fontFamily: 'var(--font-mono)',
-                }}
-                onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-                onBlur={(e) => (e.target.style.borderColor = 'var(--border)')}
+                aria-invalid={errors.whatsapp ? 'true' : undefined}
+                aria-describedby={errors.whatsapp ? 'edit-whatsapp-error' : undefined}
+                style={{ ...fieldStyle(!!errors.whatsapp), fontFamily: 'var(--font-mono)' }}
               />
+              {errors.whatsapp && (
+                <p id="edit-whatsapp-error" className="text-xs text-coral" role="alert">
+                  {errors.whatsapp}
+                </p>
+              )}
             </div>
           </div>
+
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-            <div className="eyebrow">Objetivo clínico</div>
+            <label className="eyebrow" htmlFor="edit-objective">
+              Objetivo clínico
+            </label>
             <select
+              id="edit-objective"
               value={objective}
               onChange={(e) => setObjective(e.target.value as ObjectiveOption)}
-              style={{ padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 6, fontSize: 13, background: 'var(--surface)', color: 'var(--fg)', width: '100%' }}
+              style={{
+                padding: '8px 10px',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                fontSize: 13,
+                background: 'var(--surface)',
+                color: 'var(--fg)',
+                width: '100%',
+              }}
             >
-              {OBJECTIVE_KEYS.map(o => <option key={o} value={o}>{OBJECTIVE_LABELS[o]}</option>)}
+              {OBJECTIVE_KEYS.map((o) => (
+                <option key={o} value={o}>
+                  {OBJECTIVE_LABELS[o]}
+                </option>
+              ))}
             </select>
           </div>
+
+          {submitError && (
+            <div
+              style={{
+                padding: '10px 12px',
+                background: 'rgba(255,107,74,0.1)',
+                borderRadius: 6,
+                fontSize: 13,
+                color: 'var(--coral)',
+              }}
+              role="alert"
+            >
+              {submitError}
+            </div>
+          )}
         </div>
         <div
           style={{
@@ -161,7 +308,12 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
           <button className="btn btn-ghost" onClick={onClose}>
             Cancelar
           </button>
-          <button className="btn btn-primary" onClick={handle} disabled={!name.trim() || updateMutation.isPending} style={{ opacity: name.trim() ? 1 : 0.45 }}>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={!canSubmit}
+            style={{ opacity: canSubmit ? 1 : 0.45 }}
+          >
             <IconCheck size={13} /> Salvar
           </button>
         </div>

--- a/frontend/src/components/patient/NewBiometryModal.tsx
+++ b/frontend/src/components/patient/NewBiometryModal.tsx
@@ -3,6 +3,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
 import type { BiometryAssessmentDTO, CreateBiometryAssessmentRequest } from '../../types/patient';
 import { resolveMutationErrorMessage } from '../../stores/patientStore';
 import { IconPlus, IconX } from '../icons';
+import { useValidation } from '../../hooks/useValidation';
 
 const SKINFOLD_KEYS = [
   'peitoral',
@@ -51,24 +52,100 @@ interface NewBiometryModalProps {
 }
 
 export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiometryModalProps) {
-  const [form, setForm] = React.useState({
-    assessmentDate: new Date().toISOString().slice(0, 10),
-    weight: '',
-    bodyFatPercent: '',
-    leanMassKg: '',
-    waterPercent: '',
-    visceralFatLevel: '',
-    bmrKcal: '',
-    notes: '',
-  });
-  const [skinfoldValues, setSkinfoldValues] = React.useState<Record<string, string>>({});
-  const [perimetryValues, setPerimetryValues] = React.useState<Record<string, string>>({});
-  const [validationError, setValidationError] = React.useState<string | null>(null);
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+  } = useValidation(
+    {
+      assessmentDate: new Date().toISOString().slice(0, 10),
+      weight: '',
+      bodyFatPercent: '',
+      leanMassKg: '',
+      waterPercent: '',
+      visceralFatLevel: '',
+      bmrKcal: '',
+      notes: '',
+    } as Record<string, string>,
+    {
+      assessmentDate: {
+        required: true,
+        requiredMessage: 'Data da avaliação é obrigatória.',
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const d = new Date(v);
+          if (isNaN(d.getTime())) return 'Data inválida.';
+          if (d > new Date()) return 'Data não pode ser no futuro.';
+          return undefined;
+        },
+      },
+      weight: {
+        required: true,
+        requiredMessage: 'Peso é obrigatório.',
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n) || n <= 0) return 'Informe um peso válido em kg.';
+          if (n > 500) return 'Peso deve ser menor que 500 kg.';
+          return undefined;
+        },
+      },
+      bodyFatPercent: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido para % de gordura.';
+          if (n <= 0 || n > 100) return '% de gordura deve estar entre 0,01 e 100.';
+          return undefined;
+        },
+      },
+      leanMassKg: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido para massa magra.';
+          if (n < 0) return 'Massa magra não pode ser negativa.';
+          return undefined;
+        },
+      },
+      waterPercent: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido para % de água.';
+          if (n < 0 || n > 100) return '% de água deve estar entre 0 e 100.';
+          return undefined;
+        },
+      },
+      visceralFatLevel: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n) || !Number.isInteger(n))
+            return 'Nível de gordura visceral deve ser um número inteiro.';
+          if (n < 0) return 'Nível de gordura visceral não pode ser negativo.';
+          return undefined;
+        },
+      },
+      bmrKcal: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = parseFloat(v.replace(',', '.'));
+          if (!Number.isFinite(n) || !Number.isInteger(n)) return 'TMB deve ser um número inteiro.';
+          if (n < 0) return 'TMB não pode ser negativa.';
+          return undefined;
+        },
+      },
+    },
+  );
 
-  const set = (k: string, v: string) => {
-    setValidationError(null);
-    setForm((f) => ({ ...f, [k]: v }));
-  };
+  const [skinfoldValues, setSkinfoldValues] = React.useState<Record<string, string>>({});
+  const [skinfoldErrors, setSkinfoldErrors] = React.useState<Record<string, string>>({});
+  const [perimetryValues, setPerimetryValues] = React.useState<Record<string, string>>({});
+  const [perimetryErrors, setPerimetryErrors] = React.useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
 
   const parseDecimal = (rawValue: string): number | null => {
     const normalized = rawValue.trim().replace(',', '.');
@@ -83,111 +160,82 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
     return parsed;
   };
 
+  const validateSkinfold = (key: string, value: string): string | undefined => {
+    if (!value.trim()) return undefined;
+    const parsed = parseDecimal(value);
+    if (parsed == null) return `Valor inválido em ${SKINFOLD_LABELS[key]}.`;
+    if (parsed < 0) return `${SKINFOLD_LABELS[key]} não pode ser negativo.`;
+    return undefined;
+  };
+
+  const validatePerimetry = (key: string, value: string): string | undefined => {
+    if (!value.trim()) return undefined;
+    const parsed = parseDecimal(value);
+    if (parsed == null) return `Valor inválido em ${PERIMETRY_LABELS[key]}.`;
+    if (parsed < 0) return `${PERIMETRY_LABELS[key]} não pode ser negativo.`;
+    return undefined;
+  };
+
   const handleSubmit = () => {
-    setValidationError(null);
+    setSubmitError(null);
+
+    if (!validateAll()) return;
+
+    let hasInvalid = false;
+    const newSkinfoldErrors: Record<string, string> = {};
+    for (const key of SKINFOLD_KEYS) {
+      const val = skinfoldValues[key]?.trim() ?? '';
+      if (val) {
+        const err = validateSkinfold(key, val);
+        if (err) {
+          newSkinfoldErrors[key] = err;
+          hasInvalid = true;
+        }
+      }
+    }
+    setSkinfoldErrors(newSkinfoldErrors);
+
+    const newPerimetryErrors: Record<string, string> = {};
+    for (const key of PERIMETRY_KEYS) {
+      const val = perimetryValues[key]?.trim() ?? '';
+      if (val) {
+        const err = validatePerimetry(key, val);
+        if (err) {
+          newPerimetryErrors[key] = err;
+          hasInvalid = true;
+        }
+      }
+    }
+    setPerimetryErrors(newPerimetryErrors);
+
+    if (hasInvalid) return;
 
     const weight = parseDecimal(form.weight);
-    if (weight == null || weight <= 0) {
-      setValidationError('Informe um peso válido em kg.');
-      return;
-    }
-
     const bodyFatPercent = parseDecimal(form.bodyFatPercent);
-    if (form.bodyFatPercent.trim() && bodyFatPercent == null) {
-      setValidationError('Informe um valor numérico válido para % de gordura.');
-      return;
-    }
-    if (bodyFatPercent != null && (bodyFatPercent <= 0 || bodyFatPercent > 100)) {
-      setValidationError('% de gordura deve estar entre 0,01 e 100.');
-      return;
-    }
-
     const leanMassKg = parseDecimal(form.leanMassKg);
-    if (form.leanMassKg.trim() && leanMassKg == null) {
-      setValidationError('Informe um valor numérico válido para massa magra.');
-      return;
-    }
-    if (leanMassKg != null && leanMassKg < 0) {
-      setValidationError('Massa magra não pode ser negativa.');
-      return;
-    }
-
     const waterPercent = parseDecimal(form.waterPercent);
-    if (form.waterPercent.trim() && waterPercent == null) {
-      setValidationError('Informe um valor numérico válido para % de água.');
-      return;
-    }
-    if (waterPercent != null && (waterPercent < 0 || waterPercent > 100)) {
-      setValidationError('% de água deve estar entre 0 e 100.');
-      return;
-    }
-
     const visceralFatLevel = parseInteger(form.visceralFatLevel);
-    if (form.visceralFatLevel.trim() && visceralFatLevel == null) {
-      setValidationError('Nível de gordura visceral deve ser um número inteiro.');
-      return;
-    }
-    if (visceralFatLevel != null && visceralFatLevel < 0) {
-      setValidationError('Nível de gordura visceral não pode ser negativo.');
-      return;
-    }
-
     const bmrKcal = parseInteger(form.bmrKcal);
-    if (form.bmrKcal.trim() && bmrKcal == null) {
-      setValidationError('TMB deve ser um número inteiro.');
-      return;
-    }
-    if (bmrKcal != null && bmrKcal < 0) {
-      setValidationError('TMB não pode ser negativa.');
-      return;
-    }
 
-    let invalidField: string | null = null;
     const skinfolds = SKINFOLD_KEYS.flatMap((key, i) => {
       const rawValue = skinfoldValues[key]?.trim() ?? '';
       if (!rawValue) return [];
       const parsed = parseDecimal(rawValue);
-      if (parsed == null) {
-        invalidField = SKINFOLD_LABELS[key];
-        return [];
-      }
-      return [
-        {
-          measureKey: key,
-          valueMm: parsed,
-          sortOrder: i + 1,
-        },
-      ];
+      if (parsed == null) return [];
+      return [{ measureKey: key, valueMm: parsed, sortOrder: i + 1 }];
     });
-    if (invalidField) {
-      setValidationError(`Valor inválido em dobra cutânea: ${invalidField}.`);
-      return;
-    }
 
     const perimetry = PERIMETRY_KEYS.flatMap((key, i) => {
       const rawValue = perimetryValues[key]?.trim() ?? '';
       if (!rawValue) return [];
       const parsed = parseDecimal(rawValue);
-      if (parsed == null) {
-        invalidField = PERIMETRY_LABELS[key];
-        return [];
-      }
-      return [
-        {
-          measureKey: key,
-          valueCm: parsed,
-          sortOrder: i + 1,
-        },
-      ];
+      if (parsed == null) return [];
+      return [{ measureKey: key, valueCm: parsed, sortOrder: i + 1 }];
     });
-    if (invalidField) {
-      setValidationError(`Valor inválido em perimetria: ${invalidField}.`);
-      return;
-    }
 
     const payload: CreateBiometryAssessmentRequest = {
       assessmentDate: form.assessmentDate,
-      weight,
+      weight: weight!,
       bodyFatPercent,
       leanMassKg,
       waterPercent,
@@ -203,7 +251,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
         onSuccess();
       },
       onError: (error) => {
-        setValidationError(
+        setSubmitError(
           resolveMutationErrorMessage(
             error,
             'Não foi possível salvar a avaliação. Tente novamente.',
@@ -264,6 +312,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               type="date"
               value={form.assessmentDate}
               onChange={(v) => set('assessmentDate', v)}
+              onBlur={() => onBlur('assessmentDate')()}
+              error={errors.assessmentDate}
             />
             <BioField
               label="Peso (kg)"
@@ -272,6 +322,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.weight}
               onChange={(v: string) => set('weight', v)}
+              onBlur={() => onBlur('weight')()}
+              error={errors.weight}
             />
           </div>
 
@@ -286,6 +338,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.bodyFatPercent}
               onChange={(v: string) => set('bodyFatPercent', v)}
+              onBlur={() => onBlur('bodyFatPercent')()}
+              error={errors.bodyFatPercent}
             />
             <BioField
               label="Massa magra (kg)"
@@ -294,6 +348,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.leanMassKg}
               onChange={(v: string) => set('leanMassKg', v)}
+              onBlur={() => onBlur('leanMassKg')()}
+              error={errors.leanMassKg}
             />
             <BioField
               label="% Água"
@@ -302,6 +358,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.waterPercent}
               onChange={(v: string) => set('waterPercent', v)}
+              onBlur={() => onBlur('waterPercent')()}
+              error={errors.waterPercent}
             />
             <BioField
               label="Gordura visceral · nível"
@@ -310,6 +368,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.visceralFatLevel}
               onChange={(v: string) => set('visceralFatLevel', v)}
+              onBlur={() => onBlur('visceralFatLevel')()}
+              error={errors.visceralFatLevel}
             />
             <BioField
               label="TMB (kcal)"
@@ -318,6 +378,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
               mono
               value={form.bmrKcal}
               onChange={(v: string) => set('bmrKcal', v)}
+              onBlur={() => onBlur('bmrKcal')()}
+              error={errors.bmrKcal}
             />
           </div>
 
@@ -334,9 +396,26 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
                 mono
                 value={skinfoldValues[k] ?? ''}
                 onChange={(v: string) => {
-                  setValidationError(null);
                   setSkinfoldValues((prev) => ({ ...prev, [k]: v }));
+                  const err = validateSkinfold(k, v);
+                  setSkinfoldErrors((prev) => {
+                    const next = { ...prev };
+                    if (err) next[k] = err;
+                    else delete next[k];
+                    return next;
+                  });
                 }}
+                onBlur={() => {
+                  const val = skinfoldValues[k]?.trim() ?? '';
+                  const err = validateSkinfold(k, val);
+                  setSkinfoldErrors((prev) => {
+                    const next = { ...prev };
+                    if (err) next[k] = err;
+                    else delete next[k];
+                    return next;
+                  });
+                }}
+                error={skinfoldErrors[k]}
               />
             ))}
           </div>
@@ -373,9 +452,26 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
                 mono
                 value={perimetryValues[k] ?? ''}
                 onChange={(v: string) => {
-                  setValidationError(null);
                   setPerimetryValues((prev) => ({ ...prev, [k]: v }));
+                  const err = validatePerimetry(k, v);
+                  setPerimetryErrors((prev) => {
+                    const next = { ...prev };
+                    if (err) next[k] = err;
+                    else delete next[k];
+                    return next;
+                  });
                 }}
+                onBlur={() => {
+                  const val = perimetryValues[k]?.trim() ?? '';
+                  const err = validatePerimetry(k, val);
+                  setPerimetryErrors((prev) => {
+                    const next = { ...prev };
+                    if (err) next[k] = err;
+                    else delete next[k];
+                    return next;
+                  });
+                }}
+                error={perimetryErrors[k]}
               />
             ))}
           </div>
@@ -388,7 +484,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             onChange={(v) => set('notes', v)}
           />
 
-          {validationError && (
+          {submitError && (
             <div
               style={{
                 padding: '10px 12px',
@@ -397,8 +493,9 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
                 fontSize: 13,
                 color: 'var(--coral)',
               }}
+              role="alert"
             >
-              {validationError}
+              {submitError}
             </div>
           )}
         </div>
@@ -438,6 +535,8 @@ function BioField({
   mono,
   value,
   onChange,
+  onBlur,
+  error,
 }: {
   label: string;
   placeholder?: string;
@@ -446,10 +545,13 @@ function BioField({
   mono?: boolean;
   value?: string;
   onChange?: (v: string) => void;
+  onBlur?: () => void;
+  error?: string;
 }) {
+  const fieldId = label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   const style: React.CSSProperties = {
     padding: '8px 10px',
-    border: '1px solid var(--border)',
+    border: `1px solid ${error ? 'var(--coral)' : 'var(--border)'}`,
     borderRadius: 6,
     fontSize: 13,
     background: 'var(--surface)',
@@ -460,23 +562,36 @@ function BioField({
   };
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-      <div className="eyebrow">{label}</div>
+      <label className="eyebrow" htmlFor={fieldId}>
+        {label}
+      </label>
       {kind === 'textarea' ? (
         <textarea
+          id={fieldId}
           placeholder={placeholder}
           rows={2}
           value={value ?? ''}
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           style={{ ...style, resize: 'vertical', fontFamily: 'var(--font-ui)' }}
         />
       ) : (
         <input
+          id={fieldId}
           type={type || 'text'}
           placeholder={placeholder}
           value={value ?? ''}
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
+          aria-invalid={error ? 'true' : undefined}
+          aria-describedby={error ? `${fieldId}-error` : undefined}
           style={style}
         />
+      )}
+      {error && (
+        <p id={`${fieldId}-error`} className="text-xs text-coral" role="alert">
+          {error}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/components/patients/NewPatientModal.tsx
+++ b/frontend/src/components/patients/NewPatientModal.tsx
@@ -4,6 +4,7 @@ import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { OBJECTIVE_LABELS, OBJECTIVE_KEYS } from '../../types/patient';
 import type { ObjectiveOption } from '../../types/patient';
+import { useValidation } from '../../hooks/useValidation';
 
 function formatPhone(value: string): string {
   const digits = value.replace(/\D/g, '');
@@ -33,56 +34,116 @@ interface NewPatientModalProps {
 }
 
 export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps) {
-  const [form, setForm] = useState({
-    name: '',
-    objective: '' as ObjectiveOption | '',
-    birthDate: '',
-    sex: 'F' as 'F' | 'M',
-    heightCm: '',
-    whatsapp: '',
-    notes: '',
-    terms: false,
-  });
-  const set = (k: string, v: string) => setForm((f) => ({ ...f, [k]: v }));
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+    reset,
+  } = useValidation(
+    {
+      name: '',
+      objective: '',
+      birthDate: '',
+      heightCm: '',
+      whatsapp: '',
+      notes: '',
+    } as Record<string, string>,
+    {
+      name: {
+        required: true,
+        requiredMessage: 'Nome é obrigatório.',
+        minLength: 2,
+        minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+      },
+      objective: {
+        required: true,
+        requiredMessage: 'Selecione um objetivo.',
+      },
+      heightCm: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Altura deve ser um número.';
+          if (n < 50 || n > 250) return 'Altura deve estar entre 50 e 250 cm.';
+          return undefined;
+        },
+      },
+      whatsapp: {
+        custom: (v: string) => {
+          const digits = stripPhone(v).replace(/\D/g, '');
+          if (!digits) return undefined;
+          if (digits.length < 10) return 'WhatsApp deve ter pelo menos 10 dígitos.';
+          if (digits.length > 11) return 'WhatsApp deve ter no máximo 11 dígitos.';
+          return undefined;
+        },
+      },
+      birthDate: {
+        custom: (v: string) => {
+          if (!v.trim()) return undefined;
+          const d = new Date(v);
+          if (isNaN(d.getTime())) return 'Data inválida.';
+          if (d > new Date()) return 'Data não pode ser no futuro.';
+          return undefined;
+        },
+      },
+    },
+  );
+
+  const [sex, setSex] = useState<'F' | 'M'>('F');
+  const [terms, setTerms] = useState(false);
 
   const handleSubmit = () => {
-    if (!form.name.trim() || !form.objective) return;
+    if (!terms) return;
+    if (!validateAll()) return;
     onSave?.({
       name: form.name,
       objective: form.objective as ObjectiveOption,
       ...(form.birthDate ? { birthDate: form.birthDate } : {}),
-      sex: form.sex,
+      sex,
       ...(form.heightCm ? { heightCm: Number(form.heightCm) } : {}),
       ...(stripPhone(form.whatsapp) ? { whatsapp: stripPhone(form.whatsapp) } : {}),
-      terms: form.terms,
+      terms,
     });
     onClose();
   };
 
+  const handleClose = () => {
+    reset();
+    setSex('F');
+    setTerms(false);
+    onClose();
+  };
+
   return (
-    <Modal open={open} onClose={onClose} title="Novo paciente">
+    <Modal open={open} onClose={handleClose} title="Novo paciente">
       <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
         <Input
           label="Nome completo"
           placeholder="ex: Ana Beatriz Lima"
+          error={errors.name}
           value={form.name}
           onChange={(e) => set('name', e.target.value)}
+          onBlur={onBlur('name')}
         />
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
           <Input
             label="Data de nascimento"
             type="date"
+            error={errors.birthDate}
             value={form.birthDate}
             onChange={(e) => set('birthDate', e.target.value)}
+            onBlur={onBlur('birthDate')}
           />
           <div className="flex flex-col gap-1.5">
             <label className="eyebrow">Sexo</label>
             <div className="seg" style={{ height: 36 }}>
-              <button className={form.sex === 'F' ? 'active' : ''} onClick={() => set('sex', 'F')}>
+              <button className={sex === 'F' ? 'active' : ''} onClick={() => setSex('F')}>
                 Feminino
               </button>
-              <button className={form.sex === 'M' ? 'active' : ''} onClick={() => set('sex', 'M')}>
+              <button className={sex === 'M' ? 'active' : ''} onClick={() => setSex('M')}>
                 Masculino
               </button>
             </div>
@@ -93,17 +154,21 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
           <Input
             label="Altura (cm)"
             placeholder="168"
+            error={errors.heightCm}
             value={form.heightCm}
             onChange={(e) => set('heightCm', e.target.value)}
+            onBlur={onBlur('heightCm')}
           />
           <div className="flex flex-col gap-1.5">
             <label className="eyebrow">Objetivo</label>
             <select
               value={form.objective}
               onChange={(e) => set('objective', e.target.value)}
+              onBlur={onBlur('objective')}
+              aria-invalid={errors.objective ? 'true' : undefined}
               style={{
                 padding: '8px 10px',
-                border: '1px solid var(--border)',
+                border: `1px solid ${errors.objective ? 'var(--coral)' : 'var(--border)'}`,
                 borderRadius: 6,
                 fontSize: 13,
                 background: 'var(--surface)',
@@ -119,6 +184,11 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
                 </option>
               ))}
             </select>
+            {errors.objective && (
+              <p id="objective-error" className="text-xs text-coral" role="alert">
+                {errors.objective}
+              </p>
+            )}
           </div>
         </div>
 
@@ -133,9 +203,11 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
             onChange={(e) => set('whatsapp', formatPhone(stripPhone(e.target.value)))}
             type="tel"
             placeholder="(11) 99999-9999"
+            aria-invalid={errors.whatsapp ? 'true' : undefined}
+            aria-describedby={errors.whatsapp ? 'whatsapp-error' : undefined}
             style={{
               padding: '8px 10px',
-              border: '1px solid var(--border)',
+              border: `1px solid ${errors.whatsapp ? 'var(--coral)' : 'var(--border)'}`,
               borderRadius: 6,
               fontSize: 13,
               background: 'var(--surface)',
@@ -145,9 +217,19 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
               boxSizing: 'border-box',
               outline: 'none',
             }}
-            onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-            onBlur={(e) => (e.target.style.borderColor = 'var(--border)')}
+            onFocus={(e) => {
+              if (!errors.whatsapp) e.target.style.borderColor = 'var(--fg-muted)';
+            }}
+            onBlur={(e) => {
+              e.target.style.borderColor = errors.whatsapp ? 'var(--coral)' : 'var(--border)';
+              onBlur('whatsapp')();
+            }}
           />
+          {errors.whatsapp && (
+            <p id="whatsapp-error" className="text-xs text-coral" role="alert">
+              {errors.whatsapp}
+            </p>
+          )}
         </div>
         <div
           style={{
@@ -168,7 +250,7 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
         <Input
           label="Observações iniciais · opcional"
           placeholder="ex: histórico de diabetes, alergia a lactose"
-          value={form.notes}
+          value={form.notes ?? ''}
           onChange={(e) => set('notes', e.target.value)}
         />
 
@@ -184,8 +266,8 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
         >
           <input
             type="checkbox"
-            checked={form.terms}
-            onChange={(e) => setForm((f) => ({ ...f, terms: e.target.checked }))}
+            checked={terms}
+            onChange={(e) => setTerms(e.target.checked)}
             style={{ marginTop: 2 }}
           />
           <span>
@@ -195,12 +277,12 @@ export function NewPatientModal({ open, onClose, onSave }: NewPatientModalProps)
       </div>
 
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
-        <Button variant="ghost" onClick={onClose}>
+        <Button variant="ghost" onClick={handleClose}>
           Cancelar
         </Button>
         <Button
           variant="primary"
-          disabled={!form.name.trim() || !form.objective || !form.terms}
+          disabled={!form.name.trim() || !form.objective || !terms}
           onClick={handleSubmit}
         >
           Cadastrar paciente

--- a/frontend/src/components/plan/AddFoodModal.tsx
+++ b/frontend/src/components/plan/AddFoodModal.tsx
@@ -14,6 +14,7 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
   const [q, setQ] = useState('');
   const [selected, setSelected] = useState<Food | null>(null);
   const [referenceAmount, setReferenceAmount] = useState('');
+  const [amountError, setAmountError] = useState<string | undefined>(undefined);
   const [results, setResults] = useState<Food[]>([]);
   const [searching, setSearching] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -22,6 +23,7 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
     setQ(val);
     setSelected(null);
     setReferenceAmount('');
+    setAmountError(undefined);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!val.trim()) {
       setResults([]);
@@ -51,6 +53,7 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
   const handleSelectFood = (food: Food) => {
     setSelected(food);
     setReferenceAmount(String(food.referenceAmount));
+    setAmountError(undefined);
   };
 
   const getMacroPreview = () => {
@@ -69,11 +72,33 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
 
   const macroPreview = getMacroPreview();
 
+  const validateAmount = (val: string): string | undefined => {
+    if (!val.trim()) return 'Quantidade é obrigatória.';
+    const n = parseNumberInput(val);
+    if (n <= 0) return 'Quantidade deve ser maior que zero.';
+    return undefined;
+  };
+
+  const handleAmountBlur = () => {
+    if (referenceAmount) {
+      setReferenceAmount(String(parseNumberInput(referenceAmount)));
+      const err = validateAmount(referenceAmount);
+      setAmountError(err);
+    }
+  };
+
   const handleAdd = () => {
-    if (!selected || !referenceAmount) return;
+    if (!selected) return;
+    const err = validateAmount(referenceAmount);
+    if (err) {
+      setAmountError(err);
+      return;
+    }
+    const amount = parseNumberInput(referenceAmount);
+    if (!amount || amount <= 0) return;
     onAdd({
       foodId: selected.id,
-      referenceAmount: parseNumberInput(referenceAmount),
+      referenceAmount: amount,
     });
     onClose();
   };
@@ -212,22 +237,26 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
           {selected && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               <div>
-                <div className="eyebrow">Referência</div>
+                <label className="eyebrow" htmlFor="add-ref-amount">
+                  Referência
+                </label>
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                   <input
+                    id="add-ref-amount"
                     type="text"
                     inputMode="decimal"
                     value={referenceAmount}
-                    onChange={(e) => setReferenceAmount(sanitizeNumberInput(e.target.value))}
-                    onBlur={() => {
-                      if (referenceAmount) {
-                        setReferenceAmount(String(parseNumberInput(referenceAmount)));
-                      }
+                    onChange={(e) => {
+                      setReferenceAmount(sanitizeNumberInput(e.target.value));
+                      setAmountError(undefined);
                     }}
+                    onBlur={handleAmountBlur}
+                    aria-invalid={amountError ? 'true' : undefined}
+                    aria-describedby={amountError ? 'add-ref-amount-error' : undefined}
                     placeholder="0"
                     style={{
                       padding: '8px 10px',
-                      border: '1px solid var(--border)',
+                      border: `1px solid ${amountError ? 'var(--coral)' : 'var(--border)'}`,
                       borderRadius: 6,
                       fontSize: 13,
                       background: 'var(--surface)',
@@ -247,6 +276,16 @@ export function AddFoodModal({ onClose, onAdd }: AddFoodModalProps) {
                     </span>
                   )}
                 </div>
+                {amountError && (
+                  <p
+                    id="add-ref-amount-error"
+                    className="text-xs text-coral"
+                    role="alert"
+                    style={{ marginTop: 4 }}
+                  >
+                    {amountError}
+                  </p>
+                )}
               </div>
               {macroPreview && (
                 <div

--- a/frontend/src/components/plan/AddMealModal.tsx
+++ b/frontend/src/components/plan/AddMealModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useValidation } from '../../hooks/useValidation';
 import { IconPlus, IconX } from '../icons';
 
 interface AddMealModalProps {
@@ -7,39 +7,142 @@ interface AddMealModalProps {
 }
 
 export function AddMealModal({ onClose, onAdd }: AddMealModalProps) {
-  const [label, setLabel] = useState('');
-  const [time, setTime] = useState('');
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+    reset,
+  } = useValidation({ label: '', time: '' } as Record<string, string>, {
+    label: {
+      required: true,
+      requiredMessage: 'Nome da refeição é obrigatório.',
+      minLength: 2,
+      minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+    },
+    time: {
+      required: true,
+      requiredMessage: 'Horário é obrigatório.',
+    },
+  });
 
-  const valid = label.trim() && time;
+  const handleSave = () => {
+    if (!validateAll()) return;
+    onAdd({ label: form.label.trim(), time: form.time });
+  };
 
-  const handle = () => {
-    if (!valid) return;
-    onAdd({ label: label.trim(), time });
+  const handleClose = () => {
+    reset();
+    onClose();
   };
 
   return (
-    <div style={{ position: 'fixed', inset: 0, background: 'rgba(11,12,10,0.4)', zIndex: 200, display: 'grid', placeItems: 'center', padding: 20 }} onClick={onClose}>
-      <div className="card" style={{ width: 'min(420px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }} onClick={(e) => e.stopPropagation()}>
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(11,12,10,0.4)',
+        zIndex: 200,
+        display: 'grid',
+        placeItems: 'center',
+        padding: 20,
+      }}
+      onClick={handleClose}
+    >
+      <div
+        className="card"
+        style={{ width: 'min(420px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="card-h">
           <div className="title">Nova refeição</div>
           <div className="spacer" />
-          <button onClick={onClose} className="btn btn-ghost" style={{ padding: '4px 6px' }}><IconX size={14} /></button>
+          <button onClick={handleClose} className="btn btn-ghost" style={{ padding: '4px 6px' }}>
+            <IconX size={14} />
+          </button>
         </div>
         <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 12 }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Nome</div>
-              <input autoFocus value={label} onChange={(e) => setLabel(e.target.value)} placeholder="ex: Lanche pré-treino" style={{ padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 6, fontSize: 13, background: 'var(--surface)', outline: 'none', color: 'var(--fg)' }} />
+              <label className="eyebrow" htmlFor="meal-label">
+                Nome
+              </label>
+              <input
+                id="meal-label"
+                autoFocus
+                value={form.label}
+                onChange={(e) => set('label', e.target.value)}
+                onBlur={onBlur('label')}
+                aria-invalid={errors.label ? 'true' : undefined}
+                aria-describedby={errors.label ? 'meal-label-error' : undefined}
+                placeholder="ex: Lanche pré-treino"
+                style={{
+                  padding: '8px 10px',
+                  border: `1px solid ${errors.label ? 'var(--coral)' : 'var(--border)'}`,
+                  borderRadius: 6,
+                  fontSize: 13,
+                  background: 'var(--surface)',
+                  outline: 'none',
+                  color: 'var(--fg)',
+                }}
+              />
+              {errors.label && (
+                <p id="meal-label-error" className="text-xs text-coral" role="alert">
+                  {errors.label}
+                </p>
+              )}
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Horário</div>
-              <input type="time" value={time} onChange={(e) => setTime(e.target.value)} style={{ padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 6, fontSize: 13, background: 'var(--surface)', outline: 'none', color: 'var(--fg)', fontFamily: 'var(--font-mono)' }} />
+              <label className="eyebrow" htmlFor="meal-time">
+                Horário
+              </label>
+              <input
+                id="meal-time"
+                type="time"
+                value={form.time}
+                onChange={(e) => set('time', e.target.value)}
+                onBlur={onBlur('time')}
+                aria-invalid={errors.time ? 'true' : undefined}
+                aria-describedby={errors.time ? 'meal-time-error' : undefined}
+                style={{
+                  padding: '8px 10px',
+                  border: `1px solid ${errors.time ? 'var(--coral)' : 'var(--border)'}`,
+                  borderRadius: 6,
+                  fontSize: 13,
+                  background: 'var(--surface)',
+                  outline: 'none',
+                  color: 'var(--fg)',
+                  fontFamily: 'var(--font-mono)',
+                }}
+              />
+              {errors.time && (
+                <p id="meal-time-error" className="text-xs text-coral" role="alert">
+                  {errors.time}
+                </p>
+              )}
             </div>
           </div>
         </div>
-        <div style={{ padding: '12px 20px', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'flex-end', gap: 8, background: 'var(--surface-2)' }}>
-          <button className="btn btn-ghost" onClick={onClose}>Cancelar</button>
-          <button className="btn btn-primary" disabled={!valid} onClick={handle} style={{ opacity: valid ? 1 : 0.45 }}>
+        <div
+          style={{
+            padding: '12px 20px',
+            borderTop: '1px solid var(--border)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+            background: 'var(--surface-2)',
+          }}
+        >
+          <button className="btn btn-ghost" onClick={handleClose}>
+            Cancelar
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={!form.label.trim() || !form.time}
+            onClick={handleSave}
+            style={{ opacity: form.label.trim() && form.time ? 1 : 0.45 }}
+          >
             <IconPlus size={13} /> Criar refeição
           </button>
         </div>

--- a/frontend/src/components/plan/EditFoodModal.tsx
+++ b/frontend/src/components/plan/EditFoodModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { MealFood } from '../../types/plan';
 import { FOOD_UNIT_SYMBOLS } from '../../types/food';
 import { IconX, IconCheck } from '../icons';
+import { useValidation } from '../../hooks/useValidation';
 
 interface EditFoodModalProps {
   item: MealFood;
@@ -10,76 +11,273 @@ interface EditFoodModalProps {
 }
 
 export function EditFoodModal({ item, onClose, onSave }: EditFoodModalProps) {
-  const [foodName, setFoodName] = useState(item.foodName);
-  const [prep, setPrep] = useState(item.prep);
-  const [referenceAmount, setReferenceAmount] = useState(String(item.referenceAmount));
-  const [kcal, setKcal] = useState(String(item.kcal));
-  const [prot, setProt] = useState(String(item.prot));
-  const [carb, setCarb] = useState(String(item.carb));
-  const [fat, setFat] = useState(String(item.fat));
   const unitSymbol = FOOD_UNIT_SYMBOLS[item.unit as keyof typeof FOOD_UNIT_SYMBOLS] || 'g';
+  const [prep, setPrep] = useState(item.prep);
 
-  const handle = () => {
-    if (!foodName.trim()) return;
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+  } = useValidation(
+    {
+      foodName: item.foodName,
+      referenceAmount: String(item.referenceAmount),
+      kcal: String(item.kcal),
+      prot: String(item.prot),
+      carb: String(item.carb),
+      fat: String(item.fat),
+    } as Record<string, string>,
+    {
+      foodName: {
+        required: true,
+        requiredMessage: 'Nome é obrigatório.',
+        minLength: 2,
+        minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+      },
+      referenceAmount: {
+        required: true,
+        requiredMessage: 'Quantidade é obrigatória.',
+        custom: (v) => {
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n) || n <= 0) return 'Quantidade deve ser maior que zero.';
+          return undefined;
+        },
+      },
+      kcal: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      prot: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      carb: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      fat: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = Number(v.replace(',', '.'));
+          if (!Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+    },
+  );
+
+  const handleSave = () => {
+    if (!validateAll()) return;
     onSave({
       ...item,
-      foodName: foodName.trim(),
+      foodName: form.foodName.trim(),
       prep,
-      referenceAmount: Number(referenceAmount) || 0,
-      kcal: Number(kcal) || 0,
-      prot: Number(prot) || 0,
-      carb: Number(carb) || 0,
-      fat: Number(fat) || 0,
+      referenceAmount: Number(form.referenceAmount) || 0,
+      kcal: Number(form.kcal) || 0,
+      prot: Number(form.prot) || 0,
+      carb: Number(form.carb) || 0,
+      fat: Number(form.fat) || 0,
     });
   };
 
-  const field = (label: string, val: string, set: (v: string) => void, opts: { color?: string; mono?: boolean } = {}) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-      <div className="eyebrow">{label}</div>
-      <input
-        autoComplete="off"
-        value={val}
-        onChange={(e) => set(e.target.value)}
-        style={{
-          padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 6, fontSize: 13,
-          background: 'var(--surface)', outline: 'none', color: opts.color || 'var(--fg)',
-          fontFamily: opts.mono ? 'var(--font-mono)' : 'var(--font-ui)', width: '100%', boxSizing: 'border-box',
-        }}
-        onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-        onBlur={(e) => (e.target.style.borderColor = 'var(--border)')}
-      />
-    </div>
-  );
+  const fieldStyle = (hasError: boolean, mono = false): React.CSSProperties => ({
+    padding: '8px 10px',
+    border: `1px solid ${hasError ? 'var(--coral)' : 'var(--border)'}`,
+    borderRadius: 6,
+    fontSize: 13,
+    background: 'var(--surface)',
+    outline: 'none',
+    color: 'var(--fg)',
+    width: '100%',
+    boxSizing: 'border-box',
+    fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)',
+  });
 
   return (
-    <div style={{ position: 'fixed', inset: 0, background: 'rgba(11,12,10,0.4)', zIndex: 200, display: 'grid', placeItems: 'center', padding: 20 }} onClick={onClose}>
-      <div className="card" style={{ width: 'min(460px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }} onClick={(e) => e.stopPropagation()}>
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(11,12,10,0.4)',
+        zIndex: 200,
+        display: 'grid',
+        placeItems: 'center',
+        padding: 20,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="card"
+        style={{ width: 'min(460px, 100%)', boxShadow: '0 32px 80px rgba(0,0,0,0.25)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="card-h">
           <div className="title">Editar alimento</div>
           <div className="spacer" />
-          <button onClick={onClose} className="btn btn-ghost" style={{ padding: '4px 6px' }}><IconX size={14} /></button>
+          <button onClick={onClose} className="btn btn-ghost" style={{ padding: '4px 6px' }}>
+            <IconX size={14} />
+          </button>
         </div>
         <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div className="mono" style={{ fontSize: 10, color: 'var(--fg-subtle)', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+          <div
+            className="mono"
+            style={{
+              fontSize: 10,
+              color: 'var(--fg-subtle)',
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+            }}
+          >
             Alimento vinculado ao catálogo
           </div>
-          {field('Nome', foodName, setFoodName)}
-          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-end' }}>
-            <div style={{ flex: 1 }}>{field('Referência', referenceAmount, setReferenceAmount, { mono: true })}</div>
-            <div className="mono" style={{ fontSize: 13, color: 'var(--fg-muted)', paddingBottom: 12 }}>Uni: {unitSymbol}</div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="edit-food-name">
+              Nome
+            </label>
+            <input
+              id="edit-food-name"
+              autoComplete="off"
+              value={form.foodName}
+              onChange={(e) => set('foodName', e.target.value)}
+              onBlur={onBlur('foodName')}
+              aria-invalid={errors.foodName ? 'true' : undefined}
+              aria-describedby={errors.foodName ? 'edit-food-name-error' : undefined}
+              style={fieldStyle(!!errors.foodName)}
+            />
+            {errors.foodName && (
+              <p id="edit-food-name-error" className="text-xs text-coral" role="alert">
+                {errors.foodName}
+              </p>
+            )}
           </div>
-          {field('Preparo', prep, setPrep)}
-          <div className="divider"><span>Valores nutricionais (congelados)</span></div>
+
+          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-end' }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                <label className="eyebrow" htmlFor="edit-ref-amount">
+                  Referência
+                </label>
+                <input
+                  id="edit-ref-amount"
+                  autoComplete="off"
+                  value={form.referenceAmount}
+                  onChange={(e) => set('referenceAmount', e.target.value)}
+                  onBlur={onBlur('referenceAmount')}
+                  aria-invalid={errors.referenceAmount ? 'true' : undefined}
+                  aria-describedby={errors.referenceAmount ? 'edit-ref-amount-error' : undefined}
+                  style={fieldStyle(!!errors.referenceAmount, true)}
+                />
+                {errors.referenceAmount && (
+                  <p id="edit-ref-amount-error" className="text-xs text-coral" role="alert">
+                    {errors.referenceAmount}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div
+              className="mono"
+              style={{ fontSize: 13, color: 'var(--fg-muted)', paddingBottom: 12 }}
+            >
+              Uni: {unitSymbol}
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="edit-prep">
+              Preparo
+            </label>
+            <input
+              id="edit-prep"
+              value={prep}
+              onChange={(e) => setPrep(e.target.value)}
+              placeholder="ex: grelhado, cozido"
+              style={fieldStyle(false)}
+            />
+          </div>
+
+          <div className="divider">
+            <span>Valores nutricionais (congelados)</span>
+          </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10 }}>
-            {field('Kcal', kcal, setKcal, { mono: true })}
-            {field('Prot (g)', prot, setProt, { color: 'var(--sage-dim)', mono: true })}
-            {field('Carb (g)', carb, setCarb, { color: 'var(--carb)', mono: true })}
-            {field('Gord (g)', fat, setFat, { color: 'var(--sky)', mono: true })}
+            {(['kcal', 'prot', 'carb', 'fat'] as const).map((key) => {
+              const labels: Record<string, string> = {
+                kcal: 'Kcal',
+                prot: 'Prot (g)',
+                carb: 'Carb (g)',
+                fat: 'Gord (g)',
+              };
+              const colors: Record<string, string> = {
+                kcal: '',
+                prot: 'var(--sage-dim)',
+                carb: 'var(--carb)',
+                fat: 'var(--sky)',
+              };
+              return (
+                <div key={key} style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                  <label className="eyebrow" htmlFor={`edit-food-${key}`}>
+                    {labels[key]}
+                  </label>
+                  <input
+                    id={`edit-food-${key}`}
+                    autoComplete="off"
+                    value={form[key]}
+                    onChange={(e) => set(key, e.target.value)}
+                    onBlur={onBlur(key)}
+                    aria-invalid={errors[key] ? 'true' : undefined}
+                    aria-describedby={errors[key] ? `edit-food-${key}-error` : undefined}
+                    style={{
+                      ...fieldStyle(!!errors[key], true),
+                      color: colors[key] || 'var(--fg)',
+                    }}
+                  />
+                  {errors[key] && (
+                    <p id={`edit-food-${key}-error`} className="text-xs text-coral" role="alert">
+                      {errors[key]}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
-        <div style={{ padding: '12px 20px', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'flex-end', gap: 8, background: 'var(--surface-2)' }}>
-          <button className="btn btn-ghost" onClick={onClose}>Cancelar</button>
-          <button className="btn btn-primary" onClick={handle} disabled={!foodName.trim()} style={{ opacity: foodName.trim() ? 1 : 0.45 }}>
+        <div
+          style={{
+            padding: '12px 20px',
+            borderTop: '1px solid var(--border)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+            background: 'var(--surface-2)',
+          }}
+        >
+          <button className="btn btn-ghost" onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={!form.foodName.trim()}
+            style={{ opacity: form.foodName.trim() ? 1 : 0.45 }}
+          >
             <IconCheck size={13} /> Salvar
           </button>
         </div>

--- a/frontend/src/hooks/useValidation.ts
+++ b/frontend/src/hooks/useValidation.ts
@@ -1,0 +1,186 @@
+import { useState, useCallback, type ChangeEvent } from 'react';
+
+export type ValidationRule = {
+  required?: boolean;
+  requiredMessage?: string;
+  min?: number;
+  minMessage?: string;
+  max?: number;
+  maxMessage?: string;
+  minLength?: number;
+  minLengthMessage?: string;
+  maxLength?: number;
+  maxLengthMessage?: string;
+  pattern?: RegExp;
+  patternMessage?: string;
+  custom?: (value: string) => string | undefined;
+};
+
+export type FieldRules = Record<string, ValidationRule>;
+
+function validateField(value: string, rules: ValidationRule): string | undefined {
+  if (rules.required && !value.trim()) {
+    return rules.requiredMessage || 'Campo obrigatório.';
+  }
+  if (!value.trim() && !rules.required) return undefined;
+
+  if (rules.minLength && value.trim().length < rules.minLength) {
+    return rules.minLengthMessage || `Mínimo de ${rules.minLength} caracteres.`;
+  }
+  if (rules.maxLength && value.trim().length > rules.maxLength) {
+    return rules.maxLengthMessage || `Máximo de ${rules.maxLength} caracteres.`;
+  }
+  if (rules.min !== undefined) {
+    const num = Number(value.replace(',', '.'));
+    if (Number.isFinite(num) && num < rules.min) {
+      return rules.minMessage || `Valor mínimo: ${rules.min}.`;
+    }
+  }
+  if (rules.max !== undefined) {
+    const num = Number(value.replace(',', '.'));
+    if (Number.isFinite(num) && num > rules.max) {
+      return rules.maxMessage || `Valor máximo: ${rules.max}.`;
+    }
+  }
+  if (rules.pattern && !rules.pattern.test(value.trim())) {
+    return rules.patternMessage || 'Formato inválido.';
+  }
+  if (rules.custom) {
+    return rules.custom(value);
+  }
+  return undefined;
+}
+
+export function useValidation<T extends Record<string, string>>(
+  initialValues: T,
+  rules: FieldRules,
+) {
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  const set = useCallback(
+    (field: string, value: string) => {
+      setValues((prev) => ({ ...prev, [field]: value }) as T);
+      if (touched[field]) {
+        const fieldRules = rules[field];
+        if (fieldRules) {
+          const error = validateField(value, fieldRules);
+          setErrors((prev) => {
+            const next = { ...prev };
+            if (error) {
+              next[field] = error;
+            } else {
+              delete next[field];
+            }
+            return next;
+          });
+        }
+      }
+    },
+    [rules, touched],
+  );
+
+  const setField = useCallback(
+    (field: string, value: string) => {
+      set(field, value);
+    },
+    [set],
+  );
+
+  const handleInputChange = useCallback(
+    (field: string) =>
+      (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+        set(field, e.target.value);
+      },
+    [set],
+  );
+
+  const onBlur = useCallback(
+    (field: string) => () => {
+      setTouched((prev) => ({ ...prev, [field]: true }));
+      const fieldRules = rules[field];
+      const value = values[field] ?? '';
+      if (fieldRules) {
+        const error = validateField(value, fieldRules);
+        setErrors((prev) => {
+          const next = { ...prev };
+          if (error) {
+            next[field] = error;
+          } else {
+            delete next[field];
+          }
+          return next;
+        });
+      }
+    },
+    [rules, values],
+  );
+
+  const validateAll = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+    const newTouched: Record<string, boolean> = {};
+    let valid = true;
+
+    for (const field of Object.keys(rules)) {
+      newTouched[field] = true;
+      const value = values[field] ?? '';
+      const error = validateField(value, rules[field]);
+      if (error) {
+        newErrors[field] = error;
+        valid = false;
+      }
+    }
+
+    setErrors(newErrors);
+    setTouched((prev) => ({ ...prev, ...newTouched }));
+    return valid;
+  }, [rules, values]);
+
+  const reset = useCallback((newValues?: Partial<T>) => {
+    setValues((prev) => ({ ...prev, ...newValues }) as T);
+    setErrors({});
+    setTouched({});
+  }, []);
+
+  const getFieldProps = useCallback(
+    (field: string) => ({
+      value: values[field] ?? '',
+      onChange: handleInputChange(field),
+      onBlur: onBlur(field),
+      'aria-invalid': errors[field] ? ('true' as const) : undefined,
+      'aria-describedby': errors[field] ? `${field}-error` : undefined,
+    }),
+    [values, handleInputChange, onBlur, errors],
+  );
+
+  const getErrorProps = useCallback(
+    (field: string) => ({
+      id: `${field}-error`,
+      role: 'alert' as const,
+    }),
+    [],
+  );
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const canSubmit = !Object.keys(rules).some((field) => {
+    const fieldRules = rules[field];
+    if (fieldRules?.required && !(values[field] ?? '').trim()) return true;
+    return false;
+  });
+
+  return {
+    values,
+    errors,
+    touched,
+    set: setField,
+    handleInputChange,
+    onBlur,
+    validateAll,
+    reset,
+    getFieldProps,
+    getErrorProps,
+    hasErrors,
+    canSubmit,
+  };
+}

--- a/frontend/src/views/FoodsView.tsx
+++ b/frontend/src/views/FoodsView.tsx
@@ -476,8 +476,8 @@ function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => vo
           <button
             className="btn btn-primary"
             onClick={handleSave}
-            disabled={!form.name.trim()}
-            style={{ opacity: form.name.trim() ? 1 : 0.45 }}
+            disabled={!form.name.trim() || !form.referenceAmount.trim()}
+            style={{ opacity: form.name.trim() && form.referenceAmount.trim() ? 1 : 0.45 }}
           >
             <IconCheck size={13} /> Salvar
           </button>
@@ -1104,8 +1104,8 @@ function CreateFoodModal({ onClose }: { onClose: () => void }) {
           <button
             className="btn btn-primary"
             onClick={handleCreate}
-            disabled={!form.name.trim()}
-            style={{ opacity: form.name.trim() ? 1 : 0.45 }}
+            disabled={!form.name.trim() || !form.referenceAmount.trim()}
+            style={{ opacity: form.name.trim() && form.referenceAmount.trim() ? 1 : 0.45 }}
           >
             <IconCheck size={13} /> Salvar no catálogo
           </button>

--- a/frontend/src/views/FoodsView.tsx
+++ b/frontend/src/views/FoodsView.tsx
@@ -25,6 +25,7 @@ import {
   IconCheck,
   IconTrash,
 } from '../components/icons';
+import { useValidation } from '../hooks/useValidation';
 
 function MiniMacro({
   label,
@@ -156,79 +157,125 @@ function FoodMenuDropdown({
 }
 
 function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => void }) {
-  const [name, setName] = useState(food.name);
   const [category, setCategory] = useState<FoodCategoryKey>(
     REVERSE_CATEGORY_LABELS[food.category] || (food.category as FoodCategoryKey),
   );
   const [unit, setUnit] = useState<FoodUnit>(food.unit);
-  const [referenceAmount, setReferenceAmount] = useState(String(food.referenceAmount));
-  const [kcal, setKcal] = useState(String(food.kcal));
-  const [prot, setProt] = useState(String(food.prot));
-  const [carb, setCarb] = useState(String(food.carb));
-  const [fat, setFat] = useState(String(food.fat));
-  const [fiber, setFiber] = useState(String(food.fiber));
   const [prep, setPrep] = useState(food.prep);
   const updateFood = useUpdateFood();
 
-  const handle = () => {
-    if (!name.trim()) return;
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+  } = useValidation(
+    {
+      name: food.name,
+      referenceAmount: String(food.referenceAmount),
+      kcal: String(food.kcal),
+      prot: String(food.prot),
+      carb: String(food.carb),
+      fat: String(food.fat),
+      fiber: String(food.fiber),
+    } as Record<string, string>,
+    {
+      name: {
+        required: true,
+        requiredMessage: 'Nome é obrigatório.',
+        minLength: 2,
+        minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+      },
+      referenceAmount: {
+        required: true,
+        requiredMessage: 'Quantidade de referência é obrigatória.',
+        custom: (v) => {
+          const n = parseNumberInput(v);
+          if (!n || n <= 0) return 'Referência deve ser maior que zero.';
+          return undefined;
+        },
+      },
+      kcal: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      prot: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      carb: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      fat: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      fiber: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+    },
+  );
+
+  const handleSave = () => {
+    if (!validateAll()) return;
     updateFood.mutate({
       id: food.id,
       data: {
-        name: name.trim(),
+        name: form.name.trim(),
         category,
         unit,
-        referenceAmount: parseNumberInput(referenceAmount),
-        kcal: parseNumberInput(kcal),
-        prot: parseNumberInput(prot),
-        carb: parseNumberInput(carb),
-        fat: parseNumberInput(fat),
-        fiber: parseNumberInput(fiber),
+        referenceAmount: parseNumberInput(form.referenceAmount),
+        kcal: parseNumberInput(form.kcal),
+        prot: parseNumberInput(form.prot),
+        carb: parseNumberInput(form.carb),
+        fat: parseNumberInput(form.fat),
+        fiber: parseNumberInput(form.fiber),
         prep: prep || null,
       },
     });
     onClose();
   };
 
-  const field = (
-    label: string,
-    val: string,
-    set: (v: string) => void,
-    opts: { mono?: boolean; type?: string; placeholder?: string; isNumber?: boolean } = {},
-  ) => {
-    const isNumberField = opts.isNumber ?? false;
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-        <div className="eyebrow">{label}</div>
-        <input
-          value={val}
-          onChange={(e) =>
-            set(isNumberField ? sanitizeNumberInput(e.target.value) : e.target.value)
-          }
-          type={isNumberField ? 'text' : opts.type || 'text'}
-          inputMode={isNumberField ? 'decimal' : undefined}
-          placeholder={opts.placeholder || ''}
-          style={{
-            padding: '8px 10px',
-            border: '1px solid var(--border)',
-            borderRadius: 6,
-            fontSize: 13,
-            background: 'var(--surface)',
-            outline: 'none',
-            color: 'var(--fg)',
-            width: '100%',
-            boxSizing: 'border-box',
-            fontFamily: opts.mono ? 'var(--font-mono)' : 'var(--font-ui)',
-          }}
-          onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-          onBlur={(e) => {
-            e.target.style.borderColor = 'var(--border)';
-            if (isNumberField) set(String(parseNumberInput(e.target.value)));
-          }}
-        />
-      </div>
-    );
-  };
+  const fieldStyle = (hasError: boolean, mono = false): React.CSSProperties => ({
+    padding: '8px 10px',
+    border: `1px solid ${hasError ? 'var(--coral)' : 'var(--border)'}`,
+    borderRadius: 6,
+    fontSize: 13,
+    background: 'var(--surface)',
+    outline: 'none',
+    color: 'var(--fg)',
+    width: '100%',
+    boxSizing: 'border-box',
+    fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)',
+  });
 
   const unitSymbol = FOOD_UNIT_SYMBOLS[unit];
   const refLabel = unit === 'UNIDADE' ? 'unidade' : unit === 'ML' ? 'ml' : 'g';
@@ -264,11 +311,32 @@ function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => vo
           </button>
         </div>
         <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {field('Nome', name, setName)}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="edit-catalog-name">
+              Nome
+            </label>
+            <input
+              id="edit-catalog-name"
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              onBlur={onBlur('name')}
+              aria-invalid={errors.name ? 'true' : undefined}
+              aria-describedby={errors.name ? 'edit-catalog-name-error' : undefined}
+              style={fieldStyle(!!errors.name)}
+            />
+            {errors.name && (
+              <p id="edit-catalog-name-error" className="text-xs text-coral" role="alert">
+                {errors.name}
+              </p>
+            )}
+          </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Categoria</div>
+              <label className="eyebrow" htmlFor="edit-catalog-category">
+                Categoria
+              </label>
               <select
+                id="edit-catalog-category"
                 value={category}
                 onChange={(e) => setCategory(e.target.value as FoodCategoryKey)}
                 style={{
@@ -289,8 +357,11 @@ function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => vo
               </select>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Unidade</div>
+              <label className="eyebrow" htmlFor="edit-catalog-unit">
+                Unidade
+              </label>
               <select
+                id="edit-catalog-unit"
                 value={unit}
                 onChange={(e) => setUnit(e.target.value as FoodUnit)}
                 style={{
@@ -310,27 +381,84 @@ function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => vo
                 ))}
               </select>
             </div>
-            {field(`Referência (${refLabel})`, referenceAmount, setReferenceAmount, {
-              mono: true,
-              isNumber: true,
-            })}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              <label className="eyebrow" htmlFor="edit-catalog-ref">
+                Referência ({refLabel})
+              </label>
+              <input
+                id="edit-catalog-ref"
+                value={form.referenceAmount}
+                onChange={(e) => set('referenceAmount', sanitizeNumberInput(e.target.value))}
+                onBlur={() => {
+                  set('referenceAmount', String(parseNumberInput(form.referenceAmount)));
+                  onBlur('referenceAmount')();
+                }}
+                aria-invalid={errors.referenceAmount ? 'true' : undefined}
+                aria-describedby={errors.referenceAmount ? 'edit-catalog-ref-error' : undefined}
+                inputMode="decimal"
+                style={fieldStyle(!!errors.referenceAmount, true)}
+              />
+              {errors.referenceAmount && (
+                <p id="edit-catalog-ref-error" className="text-xs text-coral" role="alert">
+                  {errors.referenceAmount}
+                </p>
+              )}
+            </div>
           </div>
           <div className="divider">
             <span>
-              Valores por {referenceAmount || '?'}
+              Valores por {form.referenceAmount || '?'}
               {unitSymbol}
             </span>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 10 }}>
-            {field('Kcal', kcal, setKcal, { mono: true, isNumber: true })}
-            {field('Prot (g)', prot, setProt, { mono: true, isNumber: true })}
-            {field('Carb (g)', carb, setCarb, { mono: true, isNumber: true })}
-            {field('Gord (g)', fat, setFat, { mono: true, isNumber: true })}
-            {field('Fibra (g)', fiber, setFiber, { mono: true, isNumber: true })}
+            {(['kcal', 'prot', 'carb', 'fat', 'fiber'] as const).map((key) => {
+              const labels: Record<string, string> = {
+                kcal: 'Kcal',
+                prot: 'Prot (g)',
+                carb: 'Carb (g)',
+                fat: 'Gord (g)',
+                fiber: 'Fibra (g)',
+              };
+              return (
+                <div key={key} style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                  <label className="eyebrow" htmlFor={`edit-catalog-${key}`}>
+                    {labels[key]}
+                  </label>
+                  <input
+                    id={`edit-catalog-${key}`}
+                    value={form[key]}
+                    onChange={(e) => set(key, sanitizeNumberInput(e.target.value))}
+                    onBlur={() => {
+                      set(key, String(parseNumberInput(form[key])));
+                      onBlur(key)();
+                    }}
+                    aria-invalid={errors[key] ? 'true' : undefined}
+                    aria-describedby={errors[key] ? `edit-catalog-${key}-error` : undefined}
+                    inputMode="decimal"
+                    style={fieldStyle(!!errors[key], true)}
+                  />
+                  {errors[key] && (
+                    <p id={`edit-catalog-${key}-error`} className="text-xs text-coral" role="alert">
+                      {errors[key]}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
           </div>
-          {field('Preparo sugerido', prep, setPrep, {
-            placeholder: 'ex: grelhado, cozido no vapor',
-          })}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="edit-catalog-prep">
+              Preparo sugerido
+            </label>
+            <input
+              id="edit-catalog-prep"
+              value={prep}
+              onChange={(e) => setPrep(e.target.value)}
+              placeholder="ex: grelhado, cozido no vapor"
+              style={fieldStyle(false)}
+            />
+          </div>
         </div>
         <div
           style={{
@@ -347,9 +475,9 @@ function EditFoodCatalogModal({ food, onClose }: { food: Food; onClose: () => vo
           </button>
           <button
             className="btn btn-primary"
-            onClick={handle}
-            disabled={!name.trim()}
-            style={{ opacity: name.trim() ? 1 : 0.45 }}
+            onClick={handleSave}
+            disabled={!form.name.trim()}
+            style={{ opacity: form.name.trim() ? 1 : 0.45 }}
           >
             <IconCheck size={13} /> Salvar
           </button>
@@ -643,76 +771,123 @@ function FoodsPagination({
 }
 
 function CreateFoodModal({ onClose }: { onClose: () => void }) {
-  const [name, setName] = useState('');
   const [category, setCategory] = useState<FoodCategoryKey>('PROTEINA');
   const [unit, setUnit] = useState<FoodUnit>('GRAMAS');
-  const [referenceAmount, setReferenceAmount] = useState('');
-  const [kcal, setKcal] = useState('');
-  const [prot, setProt] = useState('');
-  const [carb, setCarb] = useState('');
-  const [fat, setFat] = useState('');
-  const [fiber, setFiber] = useState('');
   const [prep, setPrep] = useState('');
   const [portionLabel, setPortionLabel] = useState('');
   const createFood = useCreateFood();
 
-  const handle = () => {
-    if (!name.trim()) return;
+  const {
+    values: form,
+    errors,
+    set,
+    onBlur,
+    validateAll,
+  } = useValidation(
+    {
+      name: '',
+      referenceAmount: '',
+      kcal: '',
+      prot: '',
+      carb: '',
+      fat: '',
+      fiber: '',
+    } as Record<string, string>,
+    {
+      name: {
+        required: true,
+        requiredMessage: 'Nome do alimento é obrigatório.',
+        minLength: 2,
+        minLengthMessage: 'Nome deve ter pelo menos 2 caracteres.',
+      },
+      referenceAmount: {
+        required: true,
+        requiredMessage: 'Quantidade de referência é obrigatória.',
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (!n || n <= 0) return 'Referência deve ser maior que zero.';
+          return undefined;
+        },
+      },
+      kcal: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      prot: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      carb: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      fat: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+      fiber: {
+        custom: (v) => {
+          if (!v.trim()) return undefined;
+          const n = parseNumberInput(v);
+          if (n == null || !Number.isFinite(n)) return 'Valor numérico inválido.';
+          if (n < 0) return 'Valor não pode ser negativo.';
+          return undefined;
+        },
+      },
+    },
+  );
+
+  const handleCreate = () => {
+    if (!validateAll()) return;
     createFood.mutate({
-      name: name.trim(),
+      name: form.name.trim(),
       category,
       unit,
-      referenceAmount: parseNumberInput(referenceAmount),
-      kcal: parseNumberInput(kcal),
-      prot: parseNumberInput(prot),
-      carb: parseNumberInput(carb),
-      fat: parseNumberInput(fat),
-      fiber: parseNumberInput(fiber),
+      referenceAmount: parseNumberInput(form.referenceAmount),
+      kcal: parseNumberInput(form.kcal),
+      prot: parseNumberInput(form.prot),
+      carb: parseNumberInput(form.carb),
+      fat: parseNumberInput(form.fat),
+      fiber: parseNumberInput(form.fiber),
       prep: prep || null,
       portionLabel: portionLabel || null,
     });
     onClose();
   };
 
-  const field = (
-    label: string,
-    val: string,
-    set: (v: string) => void,
-    opts: { mono?: boolean; placeholder?: string; isNumber?: boolean } = {},
-  ) => {
-    const isNumberField = opts.isNumber ?? false;
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-        <div className="eyebrow">{label}</div>
-        <input
-          placeholder={opts.placeholder || ''}
-          value={val}
-          onChange={(e) =>
-            set(isNumberField ? sanitizeNumberInput(e.target.value) : e.target.value)
-          }
-          type={isNumberField ? 'text' : 'text'}
-          inputMode={isNumberField ? 'decimal' : undefined}
-          style={{
-            padding: '8px 10px',
-            border: '1px solid var(--border)',
-            borderRadius: 6,
-            fontSize: 13,
-            background: 'var(--surface)',
-            outline: 'none',
-            color: 'var(--fg)',
-            width: '100%',
-            boxSizing: 'border-box',
-            fontFamily: opts.mono ? 'var(--font-mono)' : 'var(--font-ui)',
-          }}
-          onFocus={(e) => (e.target.style.borderColor = 'var(--fg-muted)')}
-          onBlur={(e) => {
-            e.target.style.borderColor = 'var(--border)';
-            if (isNumberField) set(String(parseNumberInput(e.target.value)));
-          }}
-        />
-      </div>
-    );
-  };
+  const fieldStyle = (hasError: boolean, mono = false): React.CSSProperties => ({
+    padding: '8px 10px',
+    border: `1px solid ${hasError ? 'var(--coral)' : 'var(--border)'}`,
+    borderRadius: 6,
+    fontSize: 13,
+    background: 'var(--surface)',
+    outline: 'none',
+    color: 'var(--fg)',
+    width: '100%',
+    boxSizing: 'border-box',
+    fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)',
+  });
 
   const unitSymbol = FOOD_UNIT_SYMBOLS[unit];
   const refLabel = unit === 'UNIDADE' ? 'unidade' : unit === 'ML' ? 'ml' : 'g';
@@ -750,11 +925,33 @@ function CreateFoodModal({ onClose }: { onClose: () => void }) {
         <div
           style={{ padding: '18px 20px 20px', display: 'flex', flexDirection: 'column', gap: 14 }}
         >
-          {field('Nome do alimento', name, setName, { placeholder: 'ex: Frango desfiado' })}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="create-food-name">
+              Nome do alimento
+            </label>
+            <input
+              id="create-food-name"
+              placeholder="ex: Frango desfiado"
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              onBlur={onBlur('name')}
+              aria-invalid={errors.name ? 'true' : undefined}
+              aria-describedby={errors.name ? 'create-food-name-error' : undefined}
+              style={fieldStyle(!!errors.name)}
+            />
+            {errors.name && (
+              <p id="create-food-name-error" className="text-xs text-coral" role="alert">
+                {errors.name}
+              </p>
+            )}
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Categoria</div>
+              <label className="eyebrow" htmlFor="create-food-category">
+                Categoria
+              </label>
               <select
+                id="create-food-category"
                 value={category}
                 onChange={(e) => setCategory(e.target.value as FoodCategoryKey)}
                 style={{
@@ -775,8 +972,11 @@ function CreateFoodModal({ onClose }: { onClose: () => void }) {
               </select>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <div className="eyebrow">Unidade</div>
+              <label className="eyebrow" htmlFor="create-food-unit">
+                Unidade
+              </label>
               <select
+                id="create-food-unit"
                 value={unit}
                 onChange={(e) => setUnit(e.target.value as FoodUnit)}
                 style={{
@@ -796,31 +996,97 @@ function CreateFoodModal({ onClose }: { onClose: () => void }) {
                 ))}
               </select>
             </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              <label className="eyebrow" htmlFor="create-food-ref">
+                Referência ({refLabel})
+              </label>
+              <input
+                id="create-food-ref"
+                value={form.referenceAmount}
+                onChange={(e) => set('referenceAmount', sanitizeNumberInput(e.target.value))}
+                onBlur={() => {
+                  set('referenceAmount', String(parseNumberInput(form.referenceAmount)));
+                  onBlur('referenceAmount')();
+                }}
+                aria-invalid={errors.referenceAmount ? 'true' : undefined}
+                aria-describedby={errors.referenceAmount ? 'create-food-ref-error' : undefined}
+                inputMode="decimal"
+                placeholder={unit === 'GRAMAS' ? '100' : '1'}
+                style={fieldStyle(!!errors.referenceAmount, true)}
+              />
+              {errors.referenceAmount && (
+                <p id="create-food-ref-error" className="text-xs text-coral" role="alert">
+                  {errors.referenceAmount}
+                </p>
+              )}
+            </div>
           </div>
-          {field(`Referência (${refLabel})`, referenceAmount, setReferenceAmount, {
-            mono: true,
-            placeholder: unit === 'GRAMAS' ? '100' : '1',
-            isNumber: true,
-          })}
           <div className="divider">
             <span>
-              Valores por {referenceAmount || '?'}
+              Valores por {form.referenceAmount || '?'}
               {unitSymbol}
             </span>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 10 }}>
-            {field('Kcal', kcal, setKcal, { mono: true, isNumber: true })}
-            {field('Prot (g)', prot, setProt, { mono: true, isNumber: true })}
-            {field('Carb (g)', carb, setCarb, { mono: true, isNumber: true })}
-            {field('Gord (g)', fat, setFat, { mono: true, isNumber: true })}
-            {field('Fibra (g)', fiber, setFiber, { mono: true, isNumber: true })}
+            {(['kcal', 'prot', 'carb', 'fat', 'fiber'] as const).map((key) => {
+              const labels: Record<string, string> = {
+                kcal: 'Kcal',
+                prot: 'Prot (g)',
+                carb: 'Carb (g)',
+                fat: 'Gord (g)',
+                fiber: 'Fibra (g)',
+              };
+              return (
+                <div key={key} style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                  <label className="eyebrow" htmlFor={`create-food-${key}`}>
+                    {labels[key]}
+                  </label>
+                  <input
+                    id={`create-food-${key}`}
+                    value={form[key]}
+                    onChange={(e) => set(key, sanitizeNumberInput(e.target.value))}
+                    onBlur={() => {
+                      set(key, String(parseNumberInput(form[key])));
+                      onBlur(key)();
+                    }}
+                    aria-invalid={errors[key] ? 'true' : undefined}
+                    aria-describedby={errors[key] ? `create-food-${key}-error` : undefined}
+                    inputMode="decimal"
+                    style={fieldStyle(!!errors[key], true)}
+                  />
+                  {errors[key] && (
+                    <p id={`create-food-${key}-error`} className="text-xs text-coral" role="alert">
+                      {errors[key]}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
           </div>
-          {field('Preparo sugerido', prep, setPrep, {
-            placeholder: 'ex: grelhado, cozido no vapor',
-          })}
-          {field('Descrição da porção', portionLabel, setPortionLabel, {
-            placeholder: 'ex: 1 unidade · 100g',
-          })}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="create-food-prep">
+              Preparo sugerido
+            </label>
+            <input
+              id="create-food-prep"
+              value={prep}
+              onChange={(e) => setPrep(e.target.value)}
+              placeholder="ex: grelhado, cozido no vapor"
+              style={fieldStyle(false)}
+            />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            <label className="eyebrow" htmlFor="create-food-portion">
+              Descrição da porção
+            </label>
+            <input
+              id="create-food-portion"
+              value={portionLabel}
+              onChange={(e) => setPortionLabel(e.target.value)}
+              placeholder="ex: 1 unidade · 100g"
+              style={fieldStyle(false)}
+            />
+          </div>
         </div>
         <div
           style={{
@@ -837,9 +1103,9 @@ function CreateFoodModal({ onClose }: { onClose: () => void }) {
           </button>
           <button
             className="btn btn-primary"
-            onClick={handle}
-            disabled={!name.trim()}
-            style={{ opacity: name.trim() ? 1 : 0.45 }}
+            onClick={handleCreate}
+            disabled={!form.name.trim()}
+            style={{ opacity: form.name.trim() ? 1 : 0.45 }}
           >
             <IconCheck size={13} /> Salvar no catálogo
           </button>


### PR DESCRIPTION
## Summary

- Adiciona hook `useValidation` reutilizavel com mensagens pt-BR, aria-invalid, e bloqueio de submit
- Padroniza validacao em 8 modais/views: NewPatientModal, EditPatientModal, NewBiometryModal, AddFoodModal, AddMealModal, EditFoodModal, FoodsView, LoginView/SignupView (indiretamente via Input)
- Componente `Input` agora propaga `aria-invalid` e `aria-describedby` para acessibilidade
- Todas as mensagens de validacao em pt-BR (sem i18n, hard-coded conforme convencao do projeto)
- Submit bloqueado enquanto campos obrigatorios estao invalidos
- Feedback de erro visivel sem fechar modal antes do sucesso

## Acceptance Criteria

- [x] Pelo menos 3 modais/views com validacao padronizada (8 cobertos)
- [x] Mensagens de erro em pt-BR
- [x] aria-invalid nos campos invalidos
- [x] `npx tsc --noEmit` passa
