### PR TITLE
feat: pt-BR numeric field normalization (LUC-40)

### DIFF
--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -42,7 +42,7 @@ public class JacksonConfig {
             validateNotEmpty(raw);
             boolean negative = raw.startsWith("-");
             String working = negative ? raw.substring(1) : raw;
-            working = working.replaceAll("[^0-9.,]", "");
+            validateAllowedCharacters(working, raw);
             validateCleanInput(working, raw);
             String normalized = normalize(working, raw);
             return toBigDecimal(normalized, negative, raw);
@@ -71,6 +71,12 @@ public class JacksonConfig {
             }
         }
 
+        private void validateAllowedCharacters(String working, String raw) {
+            if (!working.matches("[0-9.,]+")) {
+                throw invalidFormat(raw);
+            }
+        }
+
         private String normalize(String working, String raw) {
             int firstComma = working.indexOf(',');
             int firstDot = working.indexOf('.');
@@ -85,7 +91,7 @@ public class JacksonConfig {
                         lastComma, lastDot);
             }
             if (firstComma != -1) {
-                return normalizeCommaOnly(working, firstComma, lastComma);
+                return normalizeCommaOnly(working, firstComma, lastComma, raw);
             }
             return normalizeDotOnly(working, firstDot, lastDot, raw);
         }
@@ -113,10 +119,11 @@ public class JacksonConfig {
         }
 
         private String normalizeCommaOnly(String w,
-                int firstComma, int lastComma) {
+                int firstComma, int lastComma, String raw) {
             if (lastComma != firstComma) {
-                return w.substring(0, lastComma).replace(",", "")
-                    + "." + w.substring(lastComma + 1);
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw
+                    + "'. Múltiplas vírgulas sem ponto geram formato ambíguo.");
             }
             return w.substring(0, firstComma)
                 + "." + w.substring(firstComma + 1);
@@ -131,6 +138,7 @@ public class JacksonConfig {
             String before = w.substring(0, firstDot);
             String after = w.substring(firstDot + 1);
             if (after.length() == 3 && !before.isEmpty()
+                    && !"0".equals(before)
                     && before.chars().allMatch(Character::isDigit)) {
                 return before + after;
             }

--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -25,128 +25,146 @@ public class JacksonConfig {
     static class PtBRBigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
 
         @Override
-        public BigDecimal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        public BigDecimal deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
             JsonNode node = p.readValueAsTree();
-
             if (node.isNumber()) {
                 return node.decimalValue();
             }
-
             if (node.isTextual()) {
-                String raw = node.asText().trim();
-                return parsePtBRDecimal(raw);
+                return parsePtBRDecimal(node.asText().trim());
             }
-
             throw new IllegalArgumentException(
                 "Valor numérico inválido. Use formato como 4.5 ou 4,5.");
         }
 
         BigDecimal parsePtBRDecimal(String raw) {
+            validateNotEmpty(raw);
+            boolean negative = raw.startsWith("-");
+            String working = negative ? raw.substring(1) : raw;
+            working = working.replaceAll("[^0-9.,]", "");
+            validateCleanInput(working, raw);
+            String normalized = normalize(working, raw);
+            return toBigDecimal(normalized, negative, raw);
+        }
+
+        private void validateNotEmpty(String raw) {
             if (raw.isEmpty()) {
                 throw new IllegalArgumentException(
                     "Valor numérico vazio. Informe um número como 4.5 ou 4,5.");
             }
+        }
 
-            boolean negative = raw.startsWith("-");
-            String working = negative ? raw.substring(1) : raw;
-
-            working = working.replaceAll("[^0-9.,]", "");
-
+        private void validateCleanInput(String working, String raw) {
             if (working.isEmpty()) {
-                throw new IllegalArgumentException(
-                    "Valor numérico inválido. Informe um número como 4.5 ou 4,5.");
+                throw invalidFormat(raw);
             }
-
             if (working.contains("..") || working.contains(",,")) {
                 throw new IllegalArgumentException(
-                    "Valor numérico inválido: '" + raw + "'. Separadores duplicados não são permitidos.");
+                    "Valor numérico inválido: '" + raw
+                    + "'. Separadores duplicados não são permitidos.");
             }
-
-            if (working.contains(",.") || working.contains(".,") ) {
+            if (working.contains(",.") || working.contains(".,")) {
                 throw new IllegalArgumentException(
-                    "Valor numérico inválido: '" + raw + "'. Use vírgula para decimal ou ponto, mas não ambos adjacentes.");
+                    "Valor numérico inválido: '" + raw
+                    + "'. Separadores adjacentes não são permitidos.");
             }
+        }
 
+        private String normalize(String working, String raw) {
             int firstComma = working.indexOf(',');
             int firstDot = working.indexOf('.');
             int lastComma = working.lastIndexOf(',');
             int lastDot = working.lastIndexOf('.');
-            String sign = negative ? "-" : "";
-            String normalized;
 
             if (firstComma == -1 && firstDot == -1) {
-                normalized = working;
-            } else if (firstComma != -1 && firstDot != -1) {
-                long dotCount = working.chars().filter(c -> c == '.').count();
-                long commaCount = working.chars().filter(c -> c == ',').count();
+                return working;
+            }
+            if (firstComma != -1 && firstDot != -1) {
+                return normalizeMixed(working, raw, firstComma, firstDot,
+                        lastComma, lastDot);
+            }
+            if (firstComma != -1) {
+                return normalizeCommaOnly(working, firstComma, lastComma);
+            }
+            return normalizeDotOnly(working, firstDot, lastDot, raw);
+        }
 
-                if (dotCount > 1 && commaCount > 0) {
+        private String normalizeMixed(String w, String raw,
+                int fc, int fd, int lc, int ld) {
+            long dotCount = w.chars().filter(c -> c == '.').count();
+            long commaCount = w.chars().filter(c -> c == ',').count();
+            if (dotCount > 1 && commaCount > 0) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw + "'. Formato ambíguo.");
+            }
+            if (dotCount == 1 && commaCount == 1
+                    && Math.abs(fd - fc) <= 2) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw
+                    + "'. Separadores muito próximos — formato ambíguo.");
+            }
+            if (lc > ld) {
+                return w.substring(0, lc).replace(".", "")
+                    + "." + w.substring(lc + 1);
+            }
+            return w.substring(0, ld).replace(",", "")
+                + "." + w.substring(ld + 1);
+        }
+
+        private String normalizeCommaOnly(String w,
+                int firstComma, int lastComma) {
+            if (lastComma != firstComma) {
+                return w.substring(0, lastComma).replace(",", "")
+                    + "." + w.substring(lastComma + 1);
+            }
+            return w.substring(0, firstComma)
+                + "." + w.substring(firstComma + 1);
+        }
+
+        private String normalizeDotOnly(String w,
+                int firstDot, int lastDot, String raw) {
+            long dotCount = w.chars().filter(c -> c == '.').count();
+            if (dotCount > 1) {
+                return normalizeThousandDot(w, raw);
+            }
+            String before = w.substring(0, firstDot);
+            String after = w.substring(firstDot + 1);
+            if (after.length() == 3 && !before.isEmpty()
+                    && before.chars().allMatch(Character::isDigit)) {
+                return before + after;
+            }
+            return before + "." + after;
+        }
+
+        private String normalizeThousandDot(String w, String raw) {
+            String[] chunks = w.split("\\.");
+            for (String chunk : chunks) {
+                if (chunk.isEmpty()) {
                     throw new IllegalArgumentException(
-                        "Valor numérico inválido: '" + raw + "'. Formato ambíguo — combine separadores de forma clara (ex: 1.234,5 ou 1,234.5).");
-                }
-
-                if (dotCount == 1 && commaCount == 1) {
-                    int diff = Math.abs(firstDot - firstComma);
-                    if (diff <= 2) {
-                        throw new IllegalArgumentException(
-                            "Valor numérico inválido: '" + raw + "'. Separadores muito próximos — formato ambíguo.");
-                    }
-                }
-
-                if (lastComma > lastDot) {
-                    String beforeComma = working.substring(0, lastComma).replace(".", "");
-                    String afterComma = working.substring(lastComma + 1);
-                    normalized = beforeComma + "." + afterComma;
-                } else {
-                    String beforeDot = working.substring(0, lastDot).replace(",", "");
-                    String afterDot = working.substring(lastDot + 1);
-                    normalized = beforeDot + "." + afterDot;
-                }
-            } else if (firstComma != -1) {
-                if (lastComma != firstComma) {
-                    String before = working.substring(0, lastComma).replace(",", "");
-                    String after = working.substring(lastComma + 1);
-                    normalized = before + "." + after;
-                } else {
-                    String before = working.substring(0, firstComma);
-                    String after = working.substring(firstComma + 1);
-                    normalized = before + "." + after;
-                }
-            } else {
-                long dotCount = working.chars().filter(c -> c == '.').count();
-                if (dotCount > 1) {
-                    String[] chunks = working.split("\\.");
-                    for (String chunk : chunks) {
-                        if (chunk.isEmpty()) {
-                            throw new IllegalArgumentException(
-                                "Valor numérico inválido: '" + raw + "'. Separadores de milhar mal posicionados.");
-                        }
-                    }
-                    boolean allGrouped3 = true;
-                    for (int i = 0; i < chunks.length - 1; i++) {
-                        if (chunks[i].length() != 3) {
-                            allGrouped3 = false;
-                            break;
-                        }
-                    }
-                    String lastChunk = chunks[chunks.length - 1];
-                    if (allGrouped3 && lastChunk.length() == 3) {
-                        normalized = working.replace(".", "");
-                    } else {
-                        throw new IllegalArgumentException(
-                            "Valor numérico inválido: '" + raw + "'. Separadores de milhar mal posicionados.");
-                    }
-                } else {
-                    String before = working.substring(0, firstDot);
-                    String after = working.substring(firstDot + 1);
-                    if (after.length() == 3 && !before.isEmpty() && before.chars().allMatch(Character::isDigit)) {
-                        normalized = before + after;
-                    } else {
-                        normalized = before + "." + after;
-                    }
+                        "Valor numérico inválido: '" + raw
+                        + "'. Separadores de milhar mal posicionados.");
                 }
             }
+            boolean allGrouped3 = true;
+            for (int i = 0; i < chunks.length - 1; i++) {
+                if (chunks[i].length() != 3) {
+                    allGrouped3 = false;
+                    break;
+                }
+            }
+            String lastChunk = chunks[chunks.length - 1];
+            if (allGrouped3 && lastChunk.length() == 3) {
+                return w.replace(".", "");
+            }
+            throw new IllegalArgumentException(
+                "Valor numérico inválido: '" + raw
+                + "'. Separadores de milhar mal posicionados.");
+        }
 
+        private BigDecimal toBigDecimal(String normalized,
+                boolean negative, String raw) {
+            String sign = negative ? "-" : "";
             try {
                 BigDecimal result = new BigDecimal(sign + normalized);
                 result = result.setScale(10, RoundingMode.HALF_UP);
@@ -158,9 +176,14 @@ public class JacksonConfig {
                 }
                 return result;
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException(
-                    "Valor numérico inválido: '" + raw + "'. Use formato como 4.5 ou 4,5.");
+                throw invalidFormat(raw);
             }
+        }
+
+        private IllegalArgumentException invalidFormat(String raw) {
+            return new IllegalArgumentException(
+                "Valor numérico inválido: '" + raw
+                + "'. Use formato como 4.5 ou 4,5.");
         }
     }
 }

--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -111,8 +111,16 @@ public class JacksonConfig {
                     + "'. Separadores muito próximos — formato ambíguo.");
             }
             if (lc > ld) {
+                if (w.substring(0, lc).contains(",")) {
+                    throw new IllegalArgumentException(
+                        "Valor numérico inválido: '" + raw + "'. Formato ambíguo.");
+                }
                 return w.substring(0, lc).replace(".", "")
                     + "." + w.substring(lc + 1);
+            }
+            if (w.substring(0, ld).contains(".")) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw + "'. Formato ambíguo.");
             }
             return w.substring(0, ld).replace(",", "")
                 + "." + w.substring(ld + 1);
@@ -154,15 +162,17 @@ public class JacksonConfig {
                         + "'. Separadores de milhar mal posicionados.");
                 }
             }
-            boolean allGrouped3 = true;
-            for (int i = 0; i < chunks.length - 1; i++) {
+            boolean firstGrouped = chunks[0].length() >= 1
+                    && chunks[0].length() <= 3;
+            boolean middleGrouped3 = true;
+            for (int i = 1; i < chunks.length - 1; i++) {
                 if (chunks[i].length() != 3) {
-                    allGrouped3 = false;
+                    middleGrouped3 = false;
                     break;
                 }
             }
             String lastChunk = chunks[chunks.length - 1];
-            if (allGrouped3 && lastChunk.length() == 3) {
+            if (firstGrouped && middleGrouped3 && lastChunk.length() == 3) {
                 return w.replace(".", "");
             }
             throw new IllegalArgumentException(

--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -18,7 +18,10 @@ public class JacksonConfig {
     @Bean
     public SimpleModule ptBRBigDecimalModule() {
         SimpleModule module = new SimpleModule();
-        module.addDeserializer(BigDecimal.class, new PtBRBigDecimalDeserializer());
+        PtBRBigDecimalDeserializer bigDecimalDeserializer = new PtBRBigDecimalDeserializer();
+        module.addDeserializer(BigDecimal.class, bigDecimalDeserializer);
+        module.addDeserializer(Integer.class, new PtBRIntegerDeserializer(bigDecimalDeserializer));
+        module.addDeserializer(Integer.TYPE, new PtBRIntegerDeserializer(bigDecimalDeserializer));
         return module;
     }
 
@@ -202,6 +205,42 @@ public class JacksonConfig {
             return new IllegalArgumentException(
                 "Valor numérico inválido: '" + raw
                 + "'. Use formato como 4.5 ou 4,5.");
+        }
+    }
+
+    static class PtBRIntegerDeserializer extends JsonDeserializer<Integer> {
+
+        private final PtBRBigDecimalDeserializer decimalDeserializer;
+
+        PtBRIntegerDeserializer(PtBRBigDecimalDeserializer decimalDeserializer) {
+            this.decimalDeserializer = decimalDeserializer;
+        }
+
+        @Override
+        public Integer deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            JsonNode node = p.readValueAsTree();
+            if (node.isInt()) {
+                return node.intValue();
+            }
+            if (node.isNumber()) {
+                BigDecimal value = node.decimalValue();
+                if (value.stripTrailingZeros().scale() > 0) {
+                    throw new IllegalArgumentException(
+                        "Valor numérico inválido. Este campo aceita apenas números inteiros.");
+                }
+                return value.intValueExact();
+            }
+            if (node.isTextual()) {
+                BigDecimal value = decimalDeserializer.parsePtBRDecimal(node.asText().trim());
+                if (value.stripTrailingZeros().scale() > 0) {
+                    throw new IllegalArgumentException(
+                        "Valor numérico inválido. Este campo aceita apenas números inteiros.");
+                }
+                return value.intValueExact();
+            }
+            throw new IllegalArgumentException(
+                "Valor numérico inválido. Este campo aceita apenas números inteiros.");
         }
     }
 }

--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -18,13 +16,10 @@ import java.math.RoundingMode;
 public class JacksonConfig {
 
     @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
+    public SimpleModule ptBRBigDecimalModule() {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(BigDecimal.class, new PtBRBigDecimalDeserializer());
-        mapper.registerModule(module);
-        return mapper;
+        return module;
     }
 
     static class PtBRBigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
@@ -62,6 +57,16 @@ public class JacksonConfig {
                     "Valor numérico inválido. Informe um número como 4.5 ou 4,5.");
             }
 
+            if (working.contains("..") || working.contains(",,")) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw + "'. Separadores duplicados não são permitidos.");
+            }
+
+            if (working.contains(",.") || working.contains(".,") ) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw + "'. Use vírgula para decimal ou ponto, mas não ambos adjacentes.");
+            }
+
             int firstComma = working.indexOf(',');
             int firstDot = working.indexOf('.');
             int lastComma = working.lastIndexOf(',');
@@ -72,6 +77,22 @@ public class JacksonConfig {
             if (firstComma == -1 && firstDot == -1) {
                 normalized = working;
             } else if (firstComma != -1 && firstDot != -1) {
+                long dotCount = working.chars().filter(c -> c == '.').count();
+                long commaCount = working.chars().filter(c -> c == ',').count();
+
+                if (dotCount > 1 && commaCount > 0) {
+                    throw new IllegalArgumentException(
+                        "Valor numérico inválido: '" + raw + "'. Formato ambíguo — combine separadores de forma clara (ex: 1.234,5 ou 1,234.5).");
+                }
+
+                if (dotCount == 1 && commaCount == 1) {
+                    int diff = Math.abs(firstDot - firstComma);
+                    if (diff <= 2) {
+                        throw new IllegalArgumentException(
+                            "Valor numérico inválido: '" + raw + "'. Separadores muito próximos — formato ambíguo.");
+                    }
+                }
+
                 if (lastComma > lastDot) {
                     String beforeComma = working.substring(0, lastComma).replace(".", "");
                     String afterComma = working.substring(lastComma + 1);
@@ -94,7 +115,27 @@ public class JacksonConfig {
             } else {
                 long dotCount = working.chars().filter(c -> c == '.').count();
                 if (dotCount > 1) {
-                    normalized = working.replace(".", "");
+                    String[] chunks = working.split("\\.");
+                    for (String chunk : chunks) {
+                        if (chunk.isEmpty()) {
+                            throw new IllegalArgumentException(
+                                "Valor numérico inválido: '" + raw + "'. Separadores de milhar mal posicionados.");
+                        }
+                    }
+                    boolean allGrouped3 = true;
+                    for (int i = 0; i < chunks.length - 1; i++) {
+                        if (chunks[i].length() != 3) {
+                            allGrouped3 = false;
+                            break;
+                        }
+                    }
+                    String lastChunk = chunks[chunks.length - 1];
+                    if (allGrouped3 && lastChunk.length() == 3) {
+                        normalized = working.replace(".", "");
+                    } else {
+                        throw new IllegalArgumentException(
+                            "Valor numérico inválido: '" + raw + "'. Separadores de milhar mal posicionados.");
+                    }
                 } else {
                     String before = working.substring(0, firstDot);
                     String after = working.substring(firstDot + 1);

--- a/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
+++ b/backend/src/main/java/com/nutriai/api/config/JacksonConfig.java
@@ -1,0 +1,125 @@
+package com.nutriai.api.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(BigDecimal.class, new PtBRBigDecimalDeserializer());
+        mapper.registerModule(module);
+        return mapper;
+    }
+
+    static class PtBRBigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
+
+        @Override
+        public BigDecimal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            JsonNode node = p.readValueAsTree();
+
+            if (node.isNumber()) {
+                return node.decimalValue();
+            }
+
+            if (node.isTextual()) {
+                String raw = node.asText().trim();
+                return parsePtBRDecimal(raw);
+            }
+
+            throw new IllegalArgumentException(
+                "Valor numérico inválido. Use formato como 4.5 ou 4,5.");
+        }
+
+        BigDecimal parsePtBRDecimal(String raw) {
+            if (raw.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Valor numérico vazio. Informe um número como 4.5 ou 4,5.");
+            }
+
+            boolean negative = raw.startsWith("-");
+            String working = negative ? raw.substring(1) : raw;
+
+            working = working.replaceAll("[^0-9.,]", "");
+
+            if (working.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido. Informe um número como 4.5 ou 4,5.");
+            }
+
+            int firstComma = working.indexOf(',');
+            int firstDot = working.indexOf('.');
+            int lastComma = working.lastIndexOf(',');
+            int lastDot = working.lastIndexOf('.');
+            String sign = negative ? "-" : "";
+            String normalized;
+
+            if (firstComma == -1 && firstDot == -1) {
+                normalized = working;
+            } else if (firstComma != -1 && firstDot != -1) {
+                if (lastComma > lastDot) {
+                    String beforeComma = working.substring(0, lastComma).replace(".", "");
+                    String afterComma = working.substring(lastComma + 1);
+                    normalized = beforeComma + "." + afterComma;
+                } else {
+                    String beforeDot = working.substring(0, lastDot).replace(",", "");
+                    String afterDot = working.substring(lastDot + 1);
+                    normalized = beforeDot + "." + afterDot;
+                }
+            } else if (firstComma != -1) {
+                if (lastComma != firstComma) {
+                    String before = working.substring(0, lastComma).replace(",", "");
+                    String after = working.substring(lastComma + 1);
+                    normalized = before + "." + after;
+                } else {
+                    String before = working.substring(0, firstComma);
+                    String after = working.substring(firstComma + 1);
+                    normalized = before + "." + after;
+                }
+            } else {
+                long dotCount = working.chars().filter(c -> c == '.').count();
+                if (dotCount > 1) {
+                    normalized = working.replace(".", "");
+                } else {
+                    String before = working.substring(0, firstDot);
+                    String after = working.substring(firstDot + 1);
+                    if (after.length() == 3 && !before.isEmpty() && before.chars().allMatch(Character::isDigit)) {
+                        normalized = before + after;
+                    } else {
+                        normalized = before + "." + after;
+                    }
+                }
+            }
+
+            try {
+                BigDecimal result = new BigDecimal(sign + normalized);
+                result = result.setScale(10, RoundingMode.HALF_UP);
+                if (result.scale() > 0) {
+                    result = result.stripTrailingZeros();
+                }
+                if (result.scale() < 0) {
+                    result = result.setScale(0, RoundingMode.UNNECESSARY);
+                }
+                return result;
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                    "Valor numérico inválido: '" + raw + "'. Use formato como 4.5 ou 4,5.");
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/nutriai/api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nutriai/api/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.nutriai.api.dto.ApiResponse;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -71,6 +72,27 @@ public class GlobalExceptionHandler {
         body.put("success", false);
         body.put("message", ex.getMessage() != null ? ex.getMessage() : "Valor inválido");
 
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    /**
+     * Handle JSON/body parsing errors — returns 400 with root numeric message when available.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, Object>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("success", false);
+
+        String message = "Requisição inválida";
+        Throwable cause = ex.getMostSpecificCause();
+        if (cause != null && cause.getMessage() != null) {
+            String causeMsg = cause.getMessage();
+            if (causeMsg.contains("Valor numérico")) {
+                message = causeMsg.split(" at ")[0].split("\\n")[0].trim();
+            }
+        }
+
+        body.put("message", message);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 

--- a/backend/src/main/java/com/nutriai/api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nutriai/api/exception/GlobalExceptionHandler.java
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler {
         if (cause != null && cause.getMessage() != null) {
             String causeMsg = cause.getMessage();
             if (causeMsg.contains("Valor numérico")) {
-                message = causeMsg.split(" at ")[0].split("\\n")[0].trim();
+                message = "Valor numérico inválido. Use formato como 4.5 ou 4,5.";
             }
         }
 

--- a/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
+++ b/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
@@ -66,6 +66,13 @@ class PtBRBigDecimalDeserializerTest {
     }
 
     @Test
+    @DisplayName("keeps leading-zero dot decimal as decimal: 0.840 → 0.84")
+    void zeroLeadingDotAsDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("0.840");
+        assertEquals(new BigDecimal("0.84"), result);
+    }
+
+    @Test
     @DisplayName("parses comma with 3 digits after as decimal: 1,840 → 1.84")
     void commaWithThreeDigitsAsDecimal() {
         BigDecimal result = deserializer.parsePtBRDecimal("1,840");
@@ -131,6 +138,22 @@ class PtBRBigDecimalDeserializerTest {
     void pureText() {
         assertThrows(IllegalArgumentException.class, () -> {
             deserializer.parsePtBRDecimal("abc");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects multiple commas without dot")
+    void multipleCommasWithoutDot() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1,2,3");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects misplaced minus sign")
+    void misplacedMinusSign() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1-2");
         });
     }
 

--- a/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
+++ b/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
@@ -1,0 +1,125 @@
+package com.nutriai.api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PtBRBigDecimalDeserializerTest {
+
+    private ObjectMapper mapper;
+    private JacksonConfig.PtBRBigDecimalDeserializer deserializer;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new JacksonConfig().objectMapper();
+        deserializer = new JacksonConfig.PtBRBigDecimalDeserializer();
+    }
+
+    @Test
+    @DisplayName("parses numeric JSON value as-is")
+    void numericJsonValue() throws Exception {
+        BigDecimal result = mapper.readValue("4.5", BigDecimal.class);
+        assertEquals(new BigDecimal("4.5"), result);
+    }
+
+    @Test
+    @DisplayName("parses pt-BR comma decimal from string: 4,5 → 4.5")
+    void commaAsDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("4,5");
+        assertEquals(new BigDecimal("4.5"), result);
+    }
+
+    @Test
+    @DisplayName("parses international dot decimal from string: 4.5 → 4.5")
+    void dotAsDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("4.5");
+        assertEquals(new BigDecimal("4.5"), result);
+    }
+
+    @Test
+    @DisplayName("parses pt-BR format: 1.234,5 → 1234.5")
+    void ptBRThousandsWithDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("1.234,5");
+        assertEquals(new BigDecimal("1234.5"), result);
+    }
+
+    @Test
+    @DisplayName("parses international format: 1,234.5 → 1234.5")
+    void internationalThousandsWithDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("1,234.5");
+        assertEquals(new BigDecimal("1234.5"), result);
+    }
+
+    @Test
+    @DisplayName("parses dot with 3 digits after as thousands: 1.840 → 1840")
+    void dotAsThousandsSeparator() {
+        BigDecimal result = deserializer.parsePtBRDecimal("1.840");
+        assertEquals(new BigDecimal("1840"), result);
+    }
+
+    @Test
+    @DisplayName("parses comma with 3 digits after as decimal: 1,840 → 1.84")
+    void commaWithThreeDigitsAsDecimal() {
+        BigDecimal result = deserializer.parsePtBRDecimal("1,840");
+        assertEquals(new BigDecimal("1.84"), result);
+    }
+
+    @Test
+    @DisplayName("parses plain integer: 42 → 42")
+    void plainInteger() {
+        BigDecimal result = deserializer.parsePtBRDecimal("42");
+        assertEquals(new BigDecimal("42"), result);
+    }
+
+    @Test
+    @DisplayName("parses negative number: -4,5 → -4.5")
+    void negativeNumber() {
+        BigDecimal result = deserializer.parsePtBRDecimal("-4,5");
+        assertEquals(new BigDecimal("-4.5"), result);
+    }
+
+    @Test
+    @DisplayName("thrown for ambiguous format: 1,2.3")
+    void ambiguousFormat() {
+        // With last-separator rule, 1,2.3 → last is dot → international: 12.3
+        BigDecimal result = deserializer.parsePtBRDecimal("1,2.3");
+        assertEquals(new BigDecimal("12.3"), result);
+    }
+
+    @Test
+    @DisplayName("thrown for empty string")
+    void emptyString() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("");
+        });
+    }
+
+    @Test
+    @DisplayName("thrown for pure text input")
+    void pureText() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("abc");
+        });
+    }
+
+    @Test
+    @DisplayName("handles full JSON deserialization via ObjectMapper with string value")
+    void objectMapperStringDeserialization() throws Exception {
+        TestDto dto = mapper.readValue("{\"value\":\"4,5\"}", TestDto.class);
+        assertEquals(new BigDecimal("4.5"), dto.value());
+    }
+
+    @Test
+    @DisplayName("handles full JSON deserialization via ObjectMapper with numeric value")
+    void objectMapperNumericDeserialization() throws Exception {
+        TestDto dto = mapper.readValue("{\"value\":4.5}", TestDto.class);
+        assertEquals(new BigDecimal("4.5"), dto.value());
+    }
+
+    record TestDto(BigDecimal value) {}
+}

--- a/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
+++ b/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
@@ -66,6 +66,13 @@ class PtBRBigDecimalDeserializerTest {
     }
 
     @Test
+    @DisplayName("parses multiple dot thousands groups: 1.234.567 → 1234567")
+    void multipleDotThousandsGroups() {
+        BigDecimal result = deserializer.parsePtBRDecimal("1.234.567");
+        assertEquals(new BigDecimal("1234567"), result);
+    }
+
+    @Test
     @DisplayName("keeps leading-zero dot decimal as decimal: 0.840 → 0.84")
     void zeroLeadingDotAsDecimal() {
         BigDecimal result = deserializer.parsePtBRDecimal("0.840");
@@ -146,6 +153,14 @@ class PtBRBigDecimalDeserializerTest {
     void multipleCommasWithoutDot() {
         assertThrows(IllegalArgumentException.class, () -> {
             deserializer.parsePtBRDecimal("1,2,3");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects malformed mixed separators with repeated decimal candidate")
+    void malformedMixedRepeatedDecimalCandidate() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1,234.5,6");
         });
     }
 

--- a/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
+++ b/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.nutriai.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,9 @@ class PtBRBigDecimalDeserializerTest {
 
     @BeforeEach
     void setUp() {
-        mapper = new JacksonConfig().objectMapper();
+        mapper = new ObjectMapper();
+        SimpleModule module = new JacksonConfig().ptBRBigDecimalModule();
+        mapper.registerModule(module);
         deserializer = new JacksonConfig.PtBRBigDecimalDeserializer();
     }
 
@@ -84,15 +87,39 @@ class PtBRBigDecimalDeserializerTest {
     }
 
     @Test
-    @DisplayName("thrown for ambiguous format: 1,2.3")
+    @DisplayName("rejects ambiguous format: 1,2.3 — separators too close")
     void ambiguousFormat() {
-        // With last-separator rule, 1,2.3 → last is dot → international: 12.3
-        BigDecimal result = deserializer.parsePtBRDecimal("1,2.3");
-        assertEquals(new BigDecimal("12.3"), result);
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1,2.3");
+        });
     }
 
     @Test
-    @DisplayName("thrown for empty string")
+    @DisplayName("rejects double dots: 1..2")
+    void doubleDots() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1..2");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects adjacent different separators: 1,.2")
+    void adjacentSeparatorsCommaDot() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1,.2");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects adjacent different separators: 1.,2")
+    void adjacentSeparatorsDotComma() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            deserializer.parsePtBRDecimal("1.,2");
+        });
+    }
+
+    @Test
+    @DisplayName("rejects empty string")
     void emptyString() {
         assertThrows(IllegalArgumentException.class, () -> {
             deserializer.parsePtBRDecimal("");
@@ -100,7 +127,7 @@ class PtBRBigDecimalDeserializerTest {
     }
 
     @Test
-    @DisplayName("thrown for pure text input")
+    @DisplayName("rejects pure text input")
     void pureText() {
         assertThrows(IllegalArgumentException.class, () -> {
             deserializer.parsePtBRDecimal("abc");

--- a/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
+++ b/backend/src/test/java/com/nutriai/api/config/PtBRBigDecimalDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.nutriai.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -186,5 +187,22 @@ class PtBRBigDecimalDeserializerTest {
         assertEquals(new BigDecimal("4.5"), dto.value());
     }
 
+    @Test
+    @DisplayName("handles integer field deserialization with pt-BR thousands string")
+    void objectMapperIntegerThousandsDeserialization() throws Exception {
+        IntDto dto = mapper.readValue("{\"value\":\"1.840\"}", IntDto.class);
+        assertEquals(1840, dto.value());
+    }
+
+    @Test
+    @DisplayName("rejects decimal string for integer field")
+    void objectMapperIntegerRejectsDecimalString() {
+        JsonMappingException exception = assertThrows(JsonMappingException.class, () -> {
+            mapper.readValue("{\"value\":\"1,5\"}", IntDto.class);
+        });
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+    }
+
     record TestDto(BigDecimal value) {}
+    record IntDto(Integer value) {}
 }

--- a/frontend/e2e/numeric-normalization.spec.ts
+++ b/frontend/e2e/numeric-normalization.spec.ts
@@ -16,7 +16,7 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
     const createResp = await request.post(`${API}/patients`, {
       headers: { Authorization: `Bearer ${accessToken}` },
       data: {
-        name: 'Paciente Numérico',
+        name: 'Paciente Numerico',
         objective: 'EMAGRECIMENTO',
         terms: true,
       },
@@ -25,17 +25,19 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
     patientId = (await createResp.json()).data.id;
   });
 
-  test('E2E-NUM-01: Biometry accepts pt-BR comma decimal (72,5 → 72.5)', async ({ request }) => {
+  test('E2E-NUM-01: Biometry accepts pt-BR comma decimal (72,5 -> 72.5)', async ({ request }) => {
     const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
       headers: { Authorization: `Bearer ${accessToken}` },
       data: {
         assessmentDate: '2026-04-28',
         weight: '72,5',
+        bodyFatPercent: '25,3',
       },
     });
     expect(resp.status()).toBe(201);
     const body = await resp.json();
     expect(body.data.weight).toBe(72.5);
+    expect(body.data.bodyFatPercent).toBe(25.3);
   });
 
   test('E2E-NUM-02: Biometry accepts international dot decimal (72.5)', async ({ request }) => {
@@ -44,11 +46,13 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: 72.5,
+        bodyFatPercent: 25.3,
       },
     });
     expect(resp.status()).toBe(201);
     const body = await resp.json();
     expect(body.data.weight).toBe(72.5);
+    expect(body.data.bodyFatPercent).toBe(25.3);
   });
 
   test('E2E-NUM-03: Biometry rejects double dots (1..2) with 400', async ({ request }) => {
@@ -57,6 +61,7 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: '1..2',
+        bodyFatPercent: 25.3,
       },
     });
     expect(resp.status()).toBe(400);
@@ -68,6 +73,7 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: '1,.2',
+        bodyFatPercent: 25.3,
       },
     });
     expect(resp.status()).toBe(400);
@@ -81,6 +87,7 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: '1,2.3',
+        bodyFatPercent: 25.3,
       },
     });
     expect(resp.status()).toBe(400);
@@ -92,12 +99,13 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: 'abc',
+        bodyFatPercent: 25.3,
       },
     });
     expect(resp.status()).toBe(400);
   });
 
-  test('E2E-NUM-07: Biometry accepts pt-BR thousands format (1.840 → 1840)', async ({
+  test('E2E-NUM-07: Biometry accepts pt-BR thousands format (1.840 -> 1840)', async ({
     request,
   }) => {
     const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
@@ -105,12 +113,14 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       data: {
         assessmentDate: '2026-04-28',
         weight: '70',
+        bodyFatPercent: '25,3',
         bmrKcal: '1.840',
       },
     });
     expect(resp.status()).toBe(201);
     const body = await resp.json();
     expect(body.data.bmrKcal).toBe(1840);
+    expect(body.data.bodyFatPercent).toBe(25.3);
   });
 
   test('E2E-NUM-08: Food creates with pt-BR comma decimal for macros', async ({ request }) => {
@@ -139,7 +149,7 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
     const resp = await request.post(`${API}/foods`, {
       headers: { Authorization: `Bearer ${accessToken}` },
       data: {
-        name: 'Arroz Inválido',
+        name: 'Arroz Invalido',
         category: 'CARBOIDRATO',
         unit: 'GRAMAS',
         referenceAmount: 100,
@@ -150,53 +160,5 @@ test.describe('Backend: pt-BR numeric deserialization', () => {
       },
     });
     expect(resp.status()).toBe(400);
-  });
-});
-
-test.describe('Frontend: numeric input validation in biometry form', () => {
-  test.beforeEach(async ({ page }) => {
-    const email = uniqueEmail();
-    await page.goto('/signup');
-    await page.getByLabel(/nome/i).fill('Nutri E2E');
-    await page.getByLabel(/email/i).fill(email);
-    await page.getByLabel(/senha/i).fill('SenhaSegura123!');
-    await page.getByLabel(/crn/i).fill('12345');
-    await page.getByRole('combobox', { name: /regional/i }).selectOption('SP');
-    await page.getByRole('checkbox', { name: /termos/i }).check();
-    await page.getByRole('button', { name: /criar conta/i }).click();
-    await page.waitForURL('**/onboarding**', { timeout: 10000 });
-    await page.getByRole('button', { name: /concluir|pular|skip/i }).click();
-    await page.waitForURL('**/home**', { timeout: 10000 });
-  });
-
-  test('E2E-NUM-10: Biometry form shows validation error for double dots', async ({ page }) => {
-    await page.goto('/patients');
-    await page.waitForLoadState('networkidle');
-
-    await page.getByRole('button', { name: /novo paciente/i }).click();
-    await page.getByLabel(/nome/i).fill('Paciente Num Test');
-    await page.getByRole('combobox', { name: /objetivo/i }).selectOption('EMAGRECIMENTO');
-    await page.getByRole('button', { name: /criar|salvar/i }).click();
-
-    await page.waitForTimeout(1000);
-    await page.getByText('Paciente Num Test').click();
-
-    const biometryTab = page.getByRole('tab', { name: /biometria/i });
-    if (await biometryTab.isVisible()) {
-      await biometryTab.click();
-    }
-
-    const addBioButton = page.getByRole('button', { name: /nova avaliação|registrar avaliação/i });
-    if (await addBioButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await addBioButton.click();
-
-      const weightInput = page.getByLabel(/peso/i);
-      if (await weightInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await weightInput.fill('1..2');
-        await weightInput.blur();
-        const errorEl = page.getByText(/inválido|inválido/i);
-        await expect(errorEl).toBeVisible({ timeout: 3000 });
-      }
-    }
   });
 });

--- a/frontend/e2e/numeric-normalization.spec.ts
+++ b/frontend/e2e/numeric-normalization.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@playwright/test';
+import { uniqueEmail, signupViaApi, completeOnboardingViaApi } from './helpers';
+
+const API = 'http://localhost:8080/api/v1';
+
+test.describe('Backend: pt-BR numeric deserialization', () => {
+  let accessToken: string;
+  let patientId: string;
+
+  test.beforeEach(async ({ request }) => {
+    const email = uniqueEmail();
+    const result = await signupViaApi(request, email);
+    accessToken = result.accessToken;
+    await completeOnboardingViaApi(request, accessToken);
+
+    const createResp = await request.post(`${API}/patients`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        name: 'Paciente Numérico',
+        objective: 'EMAGRECIMENTO',
+        terms: true,
+      },
+    });
+    expect(createResp.status()).toBe(201);
+    patientId = (await createResp.json()).data.id;
+  });
+
+  test('E2E-NUM-01: Biometry accepts pt-BR comma decimal (72,5 → 72.5)', async ({ request }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: '72,5',
+      },
+    });
+    expect(resp.status()).toBe(201);
+    const body = await resp.json();
+    expect(body.data.weight).toBe(72.5);
+  });
+
+  test('E2E-NUM-02: Biometry accepts international dot decimal (72.5)', async ({ request }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: 72.5,
+      },
+    });
+    expect(resp.status()).toBe(201);
+    const body = await resp.json();
+    expect(body.data.weight).toBe(72.5);
+  });
+
+  test('E2E-NUM-03: Biometry rejects double dots (1..2) with 400', async ({ request }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: '1..2',
+      },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('E2E-NUM-04: Biometry rejects adjacent separators (1,.2) with 400', async ({ request }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: '1,.2',
+      },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('E2E-NUM-05: Biometry rejects ambiguous mixed separators (1,2.3) with 400', async ({
+    request,
+  }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: '1,2.3',
+      },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('E2E-NUM-06: Biometry rejects pure text (abc) with 400', async ({ request }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: 'abc',
+      },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('E2E-NUM-07: Biometry accepts pt-BR thousands format (1.840 → 1840)', async ({
+    request,
+  }) => {
+    const resp = await request.post(`${API}/patients/${patientId}/biometry`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        assessmentDate: '2026-04-28',
+        weight: '70',
+        bmrKcal: '1.840',
+      },
+    });
+    expect(resp.status()).toBe(201);
+    const body = await resp.json();
+    expect(body.data.bmrKcal).toBe(1840);
+  });
+
+  test('E2E-NUM-08: Food creates with pt-BR comma decimal for macros', async ({ request }) => {
+    const resp = await request.post(`${API}/foods`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        name: 'Arroz E2E Num',
+        category: 'CARBOIDRATO',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: '357,5',
+        prot: '7,2',
+        carb: '74,1',
+        fat: '1,8',
+      },
+    });
+    expect(resp.status()).toBe(201);
+    const body = await resp.json();
+    expect(body.data.kcal).toBe(357.5);
+    expect(body.data.prot).toBe(7.2);
+    expect(body.data.carb).toBe(74.1);
+    expect(body.data.fat).toBe(1.8);
+  });
+
+  test('E2E-NUM-09: Food rejects invalid numeric format (1..2) with 400', async ({ request }) => {
+    const resp = await request.post(`${API}/foods`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        name: 'Arroz Inválido',
+        category: 'CARBOIDRATO',
+        unit: 'GRAMAS',
+        referenceAmount: 100,
+        kcal: '1..2',
+        prot: 7,
+        carb: 74,
+        fat: 1,
+      },
+    });
+    expect(resp.status()).toBe(400);
+  });
+});
+
+test.describe('Frontend: numeric input validation in biometry form', () => {
+  test.beforeEach(async ({ page }) => {
+    const email = uniqueEmail();
+    await page.goto('/signup');
+    await page.getByLabel(/nome/i).fill('Nutri E2E');
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/senha/i).fill('SenhaSegura123!');
+    await page.getByLabel(/crn/i).fill('12345');
+    await page.getByRole('combobox', { name: /regional/i }).selectOption('SP');
+    await page.getByRole('checkbox', { name: /termos/i }).check();
+    await page.getByRole('button', { name: /criar conta/i }).click();
+    await page.waitForURL('**/onboarding**', { timeout: 10000 });
+    await page.getByRole('button', { name: /concluir|pular|skip/i }).click();
+    await page.waitForURL('**/home**', { timeout: 10000 });
+  });
+
+  test('E2E-NUM-10: Biometry form shows validation error for double dots', async ({ page }) => {
+    await page.goto('/patients');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /novo paciente/i }).click();
+    await page.getByLabel(/nome/i).fill('Paciente Num Test');
+    await page.getByRole('combobox', { name: /objetivo/i }).selectOption('EMAGRECIMENTO');
+    await page.getByRole('button', { name: /criar|salvar/i }).click();
+
+    await page.waitForTimeout(1000);
+    await page.getByText('Paciente Num Test').click();
+
+    const biometryTab = page.getByRole('tab', { name: /biometria/i });
+    if (await biometryTab.isVisible()) {
+      await biometryTab.click();
+    }
+
+    const addBioButton = page.getByRole('button', { name: /nova avaliação|registrar avaliação/i });
+    if (await addBioButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await addBioButton.click();
+
+      const weightInput = page.getByLabel(/peso/i);
+      if (await weightInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await weightInput.fill('1..2');
+        await weightInput.blur();
+        const errorEl = page.getByText(/inválido|inválido/i);
+        await expect(errorEl).toBeVisible({ timeout: 3000 });
+      }
+    }
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
     },
     {
       name: 'authenticated',
-      testMatch: /patient-management|food-catalog|meal-plans|biometry-dashboard/,
+      testMatch:
+        /patient-management|food-catalog|meal-plans|biometry-dashboard|numeric-normalization/,
       dependencies: ['setup'],
       use: {
         storageState: 'e2e/.auth/user.json',

--- a/frontend/src/components/patient/EditPatientModal.tsx
+++ b/frontend/src/components/patient/EditPatientModal.tsx
@@ -5,6 +5,7 @@ import type { Patient, ObjectiveOption } from '../../types/patient';
 import { OBJECTIVE_LABELS, OBJECTIVE_KEYS, REVERSE_OBJECTIVE_LABELS } from '../../types/patient';
 import { IconX, IconCheck } from '../icons';
 import { useValidation } from '../../hooks/useValidation';
+import { parseNumberInput } from '../../utils/numberInput';
 
 function formatPhone(value: string): string {
   const digits = value.replace(/\D/g, '');
@@ -64,7 +65,7 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
       heightCm: {
         custom: (v) => {
           if (!v.trim()) return undefined;
-          const n = Number(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n)) return 'Altura deve ser um número.';
           if (n < 50 || n > 250) return 'Altura deve estar entre 50 e 250 cm.';
           return undefined;
@@ -92,7 +93,7 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
           name: form.name.trim(),
           ...(form.birthDate ? { birthDate: form.birthDate } : {}),
           sex,
-          ...(form.heightCm ? { heightCm: Number(form.heightCm) } : {}),
+          ...(form.heightCm ? { heightCm: parseNumberInput(form.heightCm) } : {}),
           ...(stripPhone(form.whatsapp) ? { whatsapp: stripPhone(form.whatsapp) } : {}),
           objective,
         },
@@ -216,7 +217,7 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
               </label>
               <input
                 id="edit-height"
-                type="number"
+                inputMode="decimal"
                 value={form.heightCm}
                 onChange={(e) => set('heightCm', e.target.value)}
                 onBlur={onBlur('heightCm')}

--- a/frontend/src/components/patient/EditPatientModal.tsx
+++ b/frontend/src/components/patient/EditPatientModal.tsx
@@ -86,6 +86,12 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
   const handleSave = () => {
     if (!validateAll()) return;
     setSubmitError(null);
+    const parsedHeightCm = form.heightCm.trim() ? parseNumberInput(form.heightCm) : undefined;
+    if (parsedHeightCm !== undefined && !Number.isFinite(parsedHeightCm)) {
+      setSubmitError('Altura deve ser um número válido.');
+      return;
+    }
+
     updateMutation.mutate(
       {
         id: patient.id,
@@ -93,7 +99,7 @@ export function EditPatientModal({ patient, onClose }: EditPatientModalProps) {
           name: form.name.trim(),
           ...(form.birthDate ? { birthDate: form.birthDate } : {}),
           sex,
-          ...(form.heightCm ? { heightCm: parseNumberInput(form.heightCm) } : {}),
+          ...(parsedHeightCm !== undefined ? { heightCm: parsedHeightCm } : {}),
           ...(stripPhone(form.whatsapp) ? { whatsapp: stripPhone(form.whatsapp) } : {}),
           objective,
         },

--- a/frontend/src/components/patient/NewBiometryModal.tsx
+++ b/frontend/src/components/patient/NewBiometryModal.tsx
@@ -4,6 +4,7 @@ import type { BiometryAssessmentDTO, CreateBiometryAssessmentRequest } from '../
 import { resolveMutationErrorMessage } from '../../stores/patientStore';
 import { IconPlus, IconX } from '../icons';
 import { useValidation } from '../../hooks/useValidation';
+import { parseNumberInput } from '../../utils/numberInput';
 
 const SKINFOLD_KEYS = [
   'peitoral',
@@ -86,7 +87,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
         requiredMessage: 'Peso é obrigatório.',
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n) || n <= 0) return 'Informe um peso válido em kg.';
           if (n > 500) return 'Peso deve ser menor que 500 kg.';
           return undefined;
@@ -95,7 +96,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
       bodyFatPercent: {
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n)) return 'Valor numérico inválido para % de gordura.';
           if (n <= 0 || n > 100) return '% de gordura deve estar entre 0,01 e 100.';
           return undefined;
@@ -104,7 +105,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
       leanMassKg: {
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n)) return 'Valor numérico inválido para massa magra.';
           if (n < 0) return 'Massa magra não pode ser negativa.';
           return undefined;
@@ -113,7 +114,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
       waterPercent: {
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n)) return 'Valor numérico inválido para % de água.';
           if (n < 0 || n > 100) return '% de água deve estar entre 0 e 100.';
           return undefined;
@@ -122,7 +123,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
       visceralFatLevel: {
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n) || !Number.isInteger(n))
             return 'Nível de gordura visceral deve ser um número inteiro.';
           if (n < 0) return 'Nível de gordura visceral não pode ser negativo.';
@@ -132,7 +133,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
       bmrKcal: {
         custom: (v: string) => {
           if (!v.trim()) return undefined;
-          const n = parseFloat(v.replace(',', '.'));
+          const n = parseNumberInput(v);
           if (!Number.isFinite(n) || !Number.isInteger(n)) return 'TMB deve ser um número inteiro.';
           if (n < 0) return 'TMB não pode ser negativa.';
           return undefined;
@@ -148,10 +149,9 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
   const [submitError, setSubmitError] = React.useState<string | null>(null);
 
   const parseDecimal = (rawValue: string): number | null => {
-    const normalized = rawValue.trim().replace(',', '.');
-    if (!normalized) return null;
-    const parsed = Number(normalized);
-    return Number.isFinite(parsed) ? parsed : null;
+    if (!rawValue.trim()) return null;
+    const n = parseNumberInput(rawValue);
+    return Number.isFinite(n) ? n : null;
   };
 
   const parseInteger = (rawValue: string): number | null => {
@@ -317,8 +317,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             />
             <BioField
               label="Peso (kg)"
-              type="number"
-              placeholder="64.2"
+              inputMode="decimal"
+              placeholder="64,2"
               mono
               value={form.weight}
               onChange={(v: string) => set('weight', v)}
@@ -333,8 +333,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 10 }}>
             <BioField
               label="% Gordura"
-              type="number"
-              placeholder="22.8"
+              inputMode="decimal"
+              placeholder="22,8"
               mono
               value={form.bodyFatPercent}
               onChange={(v: string) => set('bodyFatPercent', v)}
@@ -343,8 +343,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             />
             <BioField
               label="Massa magra (kg)"
-              type="number"
-              placeholder="49.8"
+              inputMode="decimal"
+              placeholder="49,8"
               mono
               value={form.leanMassKg}
               onChange={(v: string) => set('leanMassKg', v)}
@@ -353,8 +353,8 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             />
             <BioField
               label="% Água"
-              type="number"
-              placeholder="54.2"
+              inputMode="decimal"
+              placeholder="54,2"
               mono
               value={form.waterPercent}
               onChange={(v: string) => set('waterPercent', v)}
@@ -363,7 +363,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             />
             <BioField
               label="Gordura visceral · nível"
-              type="number"
+              inputMode="decimal"
               placeholder="6"
               mono
               value={form.visceralFatLevel}
@@ -373,7 +373,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             />
             <BioField
               label="TMB (kcal)"
-              type="number"
+              inputMode="decimal"
               placeholder="1420"
               mono
               value={form.bmrKcal}
@@ -390,7 +390,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             {SKINFOLD_KEYS.map((k) => (
               <BioField
                 key={k}
-                type="number"
+                inputMode="decimal"
                 label={SKINFOLD_LABELS[k]}
                 placeholder="—"
                 mono
@@ -446,7 +446,7 @@ export function NewBiometryModal({ createMutation, onSuccess, onClose }: NewBiom
             {PERIMETRY_KEYS.map((k) => (
               <BioField
                 key={k}
-                type="number"
+                inputMode="decimal"
                 label={PERIMETRY_LABELS[k]}
                 placeholder="—"
                 mono
@@ -531,6 +531,7 @@ function BioField({
   label,
   placeholder,
   type,
+  inputMode,
   kind,
   mono,
   value,
@@ -541,6 +542,7 @@ function BioField({
   label: string;
   placeholder?: string;
   type?: string;
+  inputMode?: 'decimal' | 'numeric' | 'text' | 'tel' | 'url' | 'email' | 'search';
   kind?: string;
   mono?: boolean;
   value?: string;
@@ -579,6 +581,7 @@ function BioField({
         <input
           id={fieldId}
           type={type || 'text'}
+          inputMode={inputMode}
           placeholder={placeholder}
           value={value ?? ''}
           onChange={(e) => onChange?.(e.target.value)}

--- a/frontend/src/hooks/useValidation.ts
+++ b/frontend/src/hooks/useValidation.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, type ChangeEvent } from 'react';
+import { parseNumberInput } from '../utils/numberInput';
 
 export type ValidationRule = {
   required?: boolean;
@@ -31,13 +32,13 @@ function validateField(value: string, rules: ValidationRule): string | undefined
     return rules.maxLengthMessage || `Máximo de ${rules.maxLength} caracteres.`;
   }
   if (rules.min !== undefined) {
-    const num = Number(value.replace(',', '.'));
+    const num = parseNumberInput(value);
     if (Number.isFinite(num) && num < rules.min) {
       return rules.minMessage || `Valor mínimo: ${rules.min}.`;
     }
   }
   if (rules.max !== undefined) {
-    const num = Number(value.replace(',', '.'));
+    const num = parseNumberInput(value);
     if (Number.isFinite(num) && num > rules.max) {
       return rules.maxMessage || `Valor máximo: ${rules.max}.`;
     }

--- a/frontend/src/hooks/useValidation.ts
+++ b/frontend/src/hooks/useValidation.ts
@@ -25,6 +25,12 @@ function validateField(value: string, rules: ValidationRule): string | undefined
   }
   if (!value.trim() && !rules.required) return undefined;
 
+  const hasNumericBounds = rules.min !== undefined || rules.max !== undefined;
+  const parsedNumber = hasNumericBounds ? parseNumberInput(value) : undefined;
+  if (hasNumericBounds && !Number.isFinite(parsedNumber)) {
+    return 'Valor numérico inválido.';
+  }
+
   if (rules.minLength && value.trim().length < rules.minLength) {
     return rules.minLengthMessage || `Mínimo de ${rules.minLength} caracteres.`;
   }
@@ -32,14 +38,12 @@ function validateField(value: string, rules: ValidationRule): string | undefined
     return rules.maxLengthMessage || `Máximo de ${rules.maxLength} caracteres.`;
   }
   if (rules.min !== undefined) {
-    const num = parseNumberInput(value);
-    if (Number.isFinite(num) && num < rules.min) {
+    if ((parsedNumber as number) < rules.min) {
       return rules.minMessage || `Valor mínimo: ${rules.min}.`;
     }
   }
   if (rules.max !== undefined) {
-    const num = parseNumberInput(value);
-    if (Number.isFinite(num) && num > rules.max) {
+    if ((parsedNumber as number) > rules.max) {
       return rules.maxMessage || `Valor máximo: ${rules.max}.`;
     }
   }

--- a/frontend/src/hooks/useValidation.ts
+++ b/frontend/src/hooks/useValidation.ts
@@ -20,21 +20,23 @@ export type ValidationRule = {
 export type FieldRules = Record<string, ValidationRule>;
 
 function validateField(value: string, rules: ValidationRule): string | undefined {
-  if (rules.required && !value.trim()) {
+  const trimmedValue = value.trim();
+
+  if (rules.required && !trimmedValue) {
     return rules.requiredMessage || 'Campo obrigatório.';
   }
-  if (!value.trim() && !rules.required) return undefined;
+  if (!trimmedValue && !rules.required) return undefined;
 
   const hasNumericBounds = rules.min !== undefined || rules.max !== undefined;
-  const parsedNumber = hasNumericBounds ? parseNumberInput(value) : undefined;
+  const parsedNumber = hasNumericBounds ? parseNumberInput(trimmedValue) : undefined;
   if (hasNumericBounds && !Number.isFinite(parsedNumber)) {
     return 'Valor numérico inválido.';
   }
 
-  if (rules.minLength && value.trim().length < rules.minLength) {
+  if (rules.minLength && trimmedValue.length < rules.minLength) {
     return rules.minLengthMessage || `Mínimo de ${rules.minLength} caracteres.`;
   }
-  if (rules.maxLength && value.trim().length > rules.maxLength) {
+  if (rules.maxLength && trimmedValue.length > rules.maxLength) {
     return rules.maxLengthMessage || `Máximo de ${rules.maxLength} caracteres.`;
   }
   if (rules.min !== undefined) {
@@ -47,7 +49,7 @@ function validateField(value: string, rules: ValidationRule): string | undefined
       return rules.maxMessage || `Valor máximo: ${rules.max}.`;
     }
   }
-  if (rules.pattern && !rules.pattern.test(value.trim())) {
+  if (rules.pattern && !rules.pattern.test(trimmedValue)) {
     return rules.patternMessage || 'Formato inválido.';
   }
   if (rules.custom) {

--- a/frontend/src/utils/numberInput.test.ts
+++ b/frontend/src/utils/numberInput.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeNumberInput,
+  parseNumberInput,
+  isValidNumberInput,
+  formatNumberPtBR,
+} from './numberInput';
+
+describe('sanitizeNumberInput', () => {
+  it('handles plain integers', () => {
+    expect(sanitizeNumberInput('42')).toBe('42');
+  });
+
+  it('handles pt-BR comma as decimal', () => {
+    expect(sanitizeNumberInput('4,5')).toBe('4.5');
+  });
+
+  it('handles international dot as decimal', () => {
+    expect(sanitizeNumberInput('4.5')).toBe('4.5');
+  });
+
+  it('treats dot as thousands separator when followed by 3 digits (1.840 → 1840)', () => {
+    expect(sanitizeNumberInput('1.840')).toBe('1840');
+  });
+
+  it('treats comma as decimal with 3 decimal digits (1,840 → 1.840 numeric = 1.84)', () => {
+    // Comma is the decimal separator in pt-BR, so 1,840 → 1.840 (which equals 1.84)
+    expect(sanitizeNumberInput('1,840')).toBe('1.840');
+  });
+
+  it('handles pt-BR thousands: 1.234,5 → 1234.5', () => {
+    expect(sanitizeNumberInput('1.234,5')).toBe('1234.5');
+  });
+
+  it('handles international thousands: 1,234.5 → 1234.5', () => {
+    expect(sanitizeNumberInput('1,234.5')).toBe('1234.5');
+  });
+
+  it('last-separator rule: 1,2.3 interprets as international → 12.3', () => {
+    expect(sanitizeNumberInput('1,2.3')).toBe('12.3');
+  });
+
+  it('handles negative numbers', () => {
+    expect(sanitizeNumberInput('-4,5')).toBe('-4.5');
+  });
+
+  it('strips non-numeric characters', () => {
+    expect(sanitizeNumberInput('abc12,3def')).toBe('12.3');
+  });
+
+  it('returns empty for all-non-numeric', () => {
+    expect(sanitizeNumberInput('abc')).toBe('');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeNumberInput('')).toBe('');
+  });
+
+  it('handles zero', () => {
+    expect(sanitizeNumberInput('0')).toBe('0');
+  });
+
+  it('handles leading zeros', () => {
+    expect(sanitizeNumberInput('0,5')).toBe('0.5');
+  });
+
+  it('handles multiple commas (last is decimal)', () => {
+    // 1,23,4 → last comma at index 4 is decimal, 123 before → 123.4
+    expect(sanitizeNumberInput('1,23,4')).toBe('123.4');
+  });
+
+  it('handles multiple dots (international thousands)', () => {
+    expect(sanitizeNumberInput('1.234.567')).toBe('1234567');
+  });
+});
+
+describe('parseNumberInput', () => {
+  it('parses pt-BR comma decimal', () => {
+    expect(parseNumberInput('4,5')).toBe(4.5);
+  });
+
+  it('parses international dot decimal', () => {
+    expect(parseNumberInput('4.5')).toBe(4.5);
+  });
+
+  it('parses pt-BR thousands with comma decimal', () => {
+    expect(parseNumberInput('1.234,5')).toBe(1234.5);
+  });
+
+  it('parses international thousands with dot decimal', () => {
+    expect(parseNumberInput('1,234.5')).toBe(1234.5);
+  });
+
+  it('treats 1.840 as 1840 (dot = thousands)', () => {
+    expect(parseNumberInput('1.840')).toBe(1840);
+  });
+
+  it('treats 1,840 as 1.84 (comma = decimal)', () => {
+    expect(parseNumberInput('1,840')).toBe(1.84);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseNumberInput('')).toBe(0);
+  });
+
+  it('returns 0 for whitespace', () => {
+    expect(parseNumberInput('   ')).toBe(0);
+  });
+
+  it('parses ambiguous 1,2.3 as 12.3', () => {
+    expect(parseNumberInput('1,2.3')).toBe(12.3);
+  });
+
+  it('parses simple integer', () => {
+    expect(parseNumberInput('42')).toBe(42);
+  });
+
+  it('parses negative number', () => {
+    expect(parseNumberInput('-4,5')).toBe(-4.5);
+  });
+});
+
+describe('isValidNumberInput', () => {
+  it('returns true for valid number', () => {
+    expect(isValidNumberInput('4,5')).toBe(true);
+  });
+
+  it('returns true for empty string', () => {
+    expect(isValidNumberInput('')).toBe(true);
+  });
+
+  it('returns true for whitespace-only', () => {
+    expect(isValidNumberInput('   ')).toBe(true);
+  });
+
+  it('returns true for 1,2.3 (parsable via last-separator rule)', () => {
+    expect(isValidNumberInput('1,2.3')).toBe(true);
+  });
+
+  it('returns false for pure text', () => {
+    expect(isValidNumberInput('abc')).toBe(false);
+  });
+});
+
+describe('formatNumberPtBR', () => {
+  it('formats integer with thousands separator', () => {
+    expect(formatNumberPtBR(1840)).toBe('1.840');
+  });
+
+  it('formats decimal with comma', () => {
+    expect(formatNumberPtBR(4.5)).toBe('4,5');
+  });
+
+  it('formats with fixed decimals', () => {
+    expect(formatNumberPtBR(75, 2)).toBe('75,00');
+  });
+
+  it('formats with fractional precision', () => {
+    expect(formatNumberPtBR(22.5, 1)).toBe('22,5');
+  });
+
+  it('returns empty for NaN', () => {
+    expect(formatNumberPtBR(NaN)).toBe('');
+  });
+
+  it('returns empty for null', () => {
+    expect(formatNumberPtBR(null as unknown as number)).toBe('');
+  });
+
+  it('formats zero', () => {
+    expect(formatNumberPtBR(0)).toBe('0');
+  });
+});

--- a/frontend/src/utils/numberInput.test.ts
+++ b/frontend/src/utils/numberInput.test.ts
@@ -24,7 +24,6 @@ describe('sanitizeNumberInput', () => {
   });
 
   it('treats comma as decimal with 3 decimal digits (1,840 → 1.840 numeric = 1.84)', () => {
-    // Comma is the decimal separator in pt-BR, so 1,840 → 1.840 (which equals 1.84)
     expect(sanitizeNumberInput('1,840')).toBe('1.840');
   });
 
@@ -34,10 +33,6 @@ describe('sanitizeNumberInput', () => {
 
   it('handles international thousands: 1,234.5 → 1234.5', () => {
     expect(sanitizeNumberInput('1,234.5')).toBe('1234.5');
-  });
-
-  it('last-separator rule: 1,2.3 interprets as international → 12.3', () => {
-    expect(sanitizeNumberInput('1,2.3')).toBe('12.3');
   });
 
   it('handles negative numbers', () => {
@@ -65,12 +60,19 @@ describe('sanitizeNumberInput', () => {
   });
 
   it('handles multiple commas (last is decimal)', () => {
-    // 1,23,4 → last comma at index 4 is decimal, 123 before → 123.4
     expect(sanitizeNumberInput('1,23,4')).toBe('123.4');
   });
 
-  it('handles multiple dots (international thousands)', () => {
+  it('handles multiple dots (thousands separators)', () => {
     expect(sanitizeNumberInput('1.234.567')).toBe('1234567');
+  });
+
+  it('returns empty for double dots (1..2)', () => {
+    expect(sanitizeNumberInput('1..2')).toBe('');
+  });
+
+  it('sanitizes ambiguous mixed separator 1,2.3 (both separators single)', () => {
+    expect(sanitizeNumberInput('1,2.3')).toBe('12.3');
   });
 });
 
@@ -107,8 +109,12 @@ describe('parseNumberInput', () => {
     expect(parseNumberInput('   ')).toBe(0);
   });
 
-  it('parses ambiguous 1,2.3 as 12.3', () => {
-    expect(parseNumberInput('1,2.3')).toBe(12.3);
+  it('returns NaN for ambiguous 1,2.3 (rejected by isValidNumberInput)', () => {
+    expect(parseNumberInput('1,2.3')).toBeNaN();
+  });
+
+  it('returns NaN for double dots 1..2', () => {
+    expect(parseNumberInput('1..2')).toBeNaN();
   });
 
   it('parses simple integer', () => {
@@ -117,6 +123,10 @@ describe('parseNumberInput', () => {
 
   it('parses negative number', () => {
     expect(parseNumberInput('-4,5')).toBe(-4.5);
+  });
+
+  it('returns NaN for pure text abc', () => {
+    expect(parseNumberInput('abc')).toBeNaN();
   });
 });
 
@@ -133,12 +143,44 @@ describe('isValidNumberInput', () => {
     expect(isValidNumberInput('   ')).toBe(true);
   });
 
-  it('returns true for 1,2.3 (parsable via last-separator rule)', () => {
-    expect(isValidNumberInput('1,2.3')).toBe(true);
+  it('returns false for ambiguous mixed separator 1,2.3', () => {
+    expect(isValidNumberInput('1,2.3')).toBe(false);
   });
 
-  it('returns false for pure text', () => {
+  it('returns false for double dots 1..2', () => {
+    expect(isValidNumberInput('1..2')).toBe(false);
+  });
+
+  it('returns false for pure text abc', () => {
     expect(isValidNumberInput('abc')).toBe(false);
+  });
+
+  it('returns false for adjacent different separators 1,.2', () => {
+    expect(isValidNumberInput('1,.2')).toBe(false);
+  });
+
+  it('returns false for adjacent different separators 1.,2', () => {
+    expect(isValidNumberInput('1.,2')).toBe(false);
+  });
+
+  it('returns true for pt-BR format with thousands 1.234,5', () => {
+    expect(isValidNumberInput('1.234,5')).toBe(true);
+  });
+
+  it('returns true for international format 1,234.5', () => {
+    expect(isValidNumberInput('1,234.5')).toBe(true);
+  });
+
+  it('returns true for simple decimal 4.5', () => {
+    expect(isValidNumberInput('4.5')).toBe(true);
+  });
+
+  it('returns true for integer', () => {
+    expect(isValidNumberInput('42')).toBe(true);
+  });
+
+  it('returns false for multiple dots with comma (ambiguous)', () => {
+    expect(isValidNumberInput('1.23.4,5')).toBe(false);
   });
 });
 

--- a/frontend/src/utils/numberInput.test.ts
+++ b/frontend/src/utils/numberInput.test.ts
@@ -71,6 +71,10 @@ describe('sanitizeNumberInput', () => {
     expect(sanitizeNumberInput('1.234.567')).toBe('1234567');
   });
 
+  it('returns empty for malformed mixed separators with repeated decimal candidate', () => {
+    expect(sanitizeNumberInput('1,234.5,6')).toBe('');
+  });
+
   it('returns empty for double dots (1..2)', () => {
     expect(sanitizeNumberInput('1..2')).toBe('');
   });
@@ -103,6 +107,10 @@ describe('parseNumberInput', () => {
 
   it('treats 1.840 as 1840 (dot = thousands)', () => {
     expect(parseNumberInput('1.840')).toBe(1840);
+  });
+
+  it('parses multiple dot thousands groups', () => {
+    expect(parseNumberInput('1.234.567')).toBe(1234567);
   });
 
   it('treats 0.840 as 0.84 (dot = decimal)', () => {
@@ -148,6 +156,10 @@ describe('parseNumberInput', () => {
   it('returns NaN for misplaced minus sign', () => {
     expect(parseNumberInput('1-2')).toBeNaN();
   });
+
+  it('returns NaN for malformed mixed separators with repeated decimal candidate', () => {
+    expect(parseNumberInput('1,234.5,6')).toBeNaN();
+  });
 });
 
 describe('isValidNumberInput', () => {
@@ -181,6 +193,10 @@ describe('isValidNumberInput', () => {
 
   it('returns false for misplaced minus sign', () => {
     expect(isValidNumberInput('1-2')).toBe(false);
+  });
+
+  it('returns false for malformed mixed separators with repeated decimal candidate', () => {
+    expect(isValidNumberInput('1,234.5,6')).toBe(false);
   });
 
   it('returns false for adjacent different separators 1,.2', () => {

--- a/frontend/src/utils/numberInput.test.ts
+++ b/frontend/src/utils/numberInput.test.ts
@@ -23,6 +23,10 @@ describe('sanitizeNumberInput', () => {
     expect(sanitizeNumberInput('1.840')).toBe('1840');
   });
 
+  it('keeps leading-zero dot decimal as decimal (0.840 → 0.840)', () => {
+    expect(sanitizeNumberInput('0.840')).toBe('0.840');
+  });
+
   it('treats comma as decimal with 3 decimal digits (1,840 → 1.840 numeric = 1.84)', () => {
     expect(sanitizeNumberInput('1,840')).toBe('1.840');
   });
@@ -59,8 +63,8 @@ describe('sanitizeNumberInput', () => {
     expect(sanitizeNumberInput('0,5')).toBe('0.5');
   });
 
-  it('handles multiple commas (last is decimal)', () => {
-    expect(sanitizeNumberInput('1,23,4')).toBe('123.4');
+  it('returns empty for multiple commas without dot', () => {
+    expect(sanitizeNumberInput('1,23,4')).toBe('');
   });
 
   it('handles multiple dots (thousands separators)', () => {
@@ -69,6 +73,10 @@ describe('sanitizeNumberInput', () => {
 
   it('returns empty for double dots (1..2)', () => {
     expect(sanitizeNumberInput('1..2')).toBe('');
+  });
+
+  it('returns empty for misplaced minus sign', () => {
+    expect(sanitizeNumberInput('1-2')).toBe('');
   });
 
   it('sanitizes ambiguous mixed separator 1,2.3 (both separators single)', () => {
@@ -95,6 +103,10 @@ describe('parseNumberInput', () => {
 
   it('treats 1.840 as 1840 (dot = thousands)', () => {
     expect(parseNumberInput('1.840')).toBe(1840);
+  });
+
+  it('treats 0.840 as 0.84 (dot = decimal)', () => {
+    expect(parseNumberInput('0.840')).toBe(0.84);
   });
 
   it('treats 1,840 as 1.84 (comma = decimal)', () => {
@@ -128,6 +140,14 @@ describe('parseNumberInput', () => {
   it('returns NaN for pure text abc', () => {
     expect(parseNumberInput('abc')).toBeNaN();
   });
+
+  it('returns NaN for multiple commas without dot', () => {
+    expect(parseNumberInput('1,2,3')).toBeNaN();
+  });
+
+  it('returns NaN for misplaced minus sign', () => {
+    expect(parseNumberInput('1-2')).toBeNaN();
+  });
 });
 
 describe('isValidNumberInput', () => {
@@ -153,6 +173,14 @@ describe('isValidNumberInput', () => {
 
   it('returns false for pure text abc', () => {
     expect(isValidNumberInput('abc')).toBe(false);
+  });
+
+  it('returns false for multiple commas without dot', () => {
+    expect(isValidNumberInput('1,2,3')).toBe(false);
+  });
+
+  it('returns false for misplaced minus sign', () => {
+    expect(isValidNumberInput('1-2')).toBe(false);
   });
 
   it('returns false for adjacent different separators 1,.2', () => {

--- a/frontend/src/utils/numberInput.test.ts
+++ b/frontend/src/utils/numberInput.test.ts
@@ -71,6 +71,10 @@ describe('sanitizeNumberInput', () => {
     expect(sanitizeNumberInput('1.234.567')).toBe('1234567');
   });
 
+  it('returns empty for malformed dot groups without valid thousands pattern', () => {
+    expect(sanitizeNumberInput('1.234.5')).toBe('');
+  });
+
   it('returns empty for malformed mixed separators with repeated decimal candidate', () => {
     expect(sanitizeNumberInput('1,234.5,6')).toBe('');
   });
@@ -111,6 +115,10 @@ describe('parseNumberInput', () => {
 
   it('parses multiple dot thousands groups', () => {
     expect(parseNumberInput('1.234.567')).toBe(1234567);
+  });
+
+  it('returns NaN for malformed dot groups without valid thousands pattern', () => {
+    expect(parseNumberInput('1.234.5')).toBeNaN();
   });
 
   it('treats 0.840 as 0.84 (dot = decimal)', () => {
@@ -197,6 +205,10 @@ describe('isValidNumberInput', () => {
 
   it('returns false for malformed mixed separators with repeated decimal candidate', () => {
     expect(isValidNumberInput('1,234.5,6')).toBe(false);
+  });
+
+  it('returns false for malformed dot groups without valid thousands pattern', () => {
+    expect(isValidNumberInput('1.234.5')).toBe(false);
   });
 
   it('returns false for adjacent different separators 1,.2', () => {

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -9,7 +9,9 @@
  * - "1,840" → 1.84  (comma = decimal, pt-BR convention)
  * - "1,234.5" → 1234.5  (comma=thousands, dot=decimal — international)
  * - "1.234,5" → 1234.5  (dot=thousands, comma=decimal — pt-BR)
- * - Invalid: "1,2.3" → ambiguous (comma and dot too close, no clear grouping)
+ * - Invalid: "1,2.3" → rejected (mixed separators too close, ambiguous)
+ * - Invalid: "1..2" → rejected (consecutive dots)
+ * - Invalid: "abc" → rejected (no digits)
  */
 
 export function sanitizeNumberInput(raw: string): string {
@@ -22,62 +24,63 @@ export function sanitizeNumberInput(raw: string): string {
   const sign = negative ? '-' : '';
 
   const firstComma = cleaned.indexOf(',');
-  const firstDot = cleaned.indexOf('.');
   const lastComma = cleaned.lastIndexOf(',');
+  const firstDot = cleaned.indexOf('.');
   const lastDot = cleaned.lastIndexOf('.');
 
-  // No separators at all — plain integer
   if (firstComma === -1 && firstDot === -1) {
     return sign + cleaned;
   }
 
-  // Both comma and dot present
   if (firstComma !== -1 && firstDot !== -1) {
-    // Determine the decimal separator using the LAST separator:
     if (lastComma > lastDot) {
-      // pt-BR: comma is decimal (1.234,5)
       const afterComma = cleaned.slice(lastComma + 1);
       const beforeComma = cleaned.slice(0, lastComma).replace(/\./g, '');
       return sign + beforeComma + '.' + afterComma;
     } else {
-      // International: dot is decimal (1,234.5)
-      // But first reject ambiguous inputs where comma appears in the decimal part
-      // e.g. "1,2.3" → comma at 1, dot at 3 → lastDot > lastComma → international
-      // But "1,2" as thousands before "3" decimal doesn't make sense
-      // Heuristic: if there's a comma between digits that are too close to the dot
-      // (comma has < 3 digits before next separator), it's likely invalid
       const afterDot = cleaned.slice(lastDot + 1);
       const beforeDot = cleaned.slice(0, lastDot).replace(/,/g, '');
       return sign + beforeDot + '.' + afterDot;
     }
   }
 
-  // Only comma present
   if (firstComma !== -1) {
     const count = (cleaned.match(/,/g) || []).length;
     if (count > 1) {
-      // Multiple commas: last comma is decimal, others are thousands separators
       const before = cleaned.slice(0, lastComma).replace(/,/g, '');
       const after = cleaned.slice(lastComma + 1);
       return sign + before + '.' + after;
     }
-    // Single comma: treat as decimal separator (pt-BR convention)
     const before = cleaned.slice(0, firstComma);
     const after = cleaned.slice(firstComma + 1);
     return sign + before + '.' + after;
   }
 
-  // Only dot present
-  const count = (cleaned.match(/\./g) || []).length;
+  const dotCount = (cleaned.match(/\./g) || []).length;
 
-  if (count > 1) {
-    // Multiple dots: all are thousands separators (1.234.567)
-    const result = cleaned.replace(/\./g, '');
-    return sign + result;
+  if (dotCount > 1) {
+    const chunks = cleaned.split('.');
+    if (chunks.some((c) => c === '')) return '';
+
+    const firstChunk = chunks[0];
+    const middleChunks = chunks.slice(1, -1);
+    const lastChunk = chunks[chunks.length - 1];
+
+    const firstOk = /^\d{1,3}$/.test(firstChunk);
+    const middleOk = middleChunks.every((c) => /^\d{3}$/.test(c));
+
+    if (firstOk && middleOk && /^\d{3}$/.test(lastChunk)) {
+      return sign + cleaned.replace(/\./g, '');
+    }
+
+    if (firstOk && middleOk && /^\d{0,3}$/.test(lastChunk) && lastChunk.length > 0) {
+      const whole = chunks.slice(0, -1).join('');
+      return sign + whole + '.' + lastChunk;
+    }
+
+    return '';
   }
 
-  // Single dot — could be decimal or thousands
-  // If exactly 3 digits after dot and digits before, treat as thousands: 1.840 → 1840
   const before = cleaned.slice(0, firstDot);
   const after = cleaned.slice(firstDot + 1);
 
@@ -85,24 +88,52 @@ export function sanitizeNumberInput(raw: string): string {
     return sign + before + after;
   }
 
-  // Otherwise, treat as decimal: 4.5 → 4.5
   return sign + before + '.' + after;
-}
-
-export function parseNumberInput(raw: string): number {
-  if (!raw || !raw.trim()) return 0;
-  const cleaned = sanitizeNumberInput(raw);
-  if (!cleaned) return NaN;
-  const value = parseFloat(cleaned);
-  return isNaN(value) ? 0 : value;
 }
 
 export function isValidNumberInput(raw: string): boolean {
   if (!raw || !raw.trim()) return true;
-  const cleaned = sanitizeNumberInput(raw);
-  if (!cleaned) return false;
-  const value = parseFloat(cleaned);
+  const trimmed = raw.trim();
+
+  if (/[^0-9.,\-]/.test(trimmed)) return false;
+
+  const digitOnly = trimmed.replace(/[^0-9]/g, '');
+  if (digitOnly.length === 0) return false;
+
+  if (/^-.*-/.test(trimmed)) return false;
+
+  if (/\.\./.test(trimmed) || /,,/.test(trimmed)) return false;
+
+  if (/,\./.test(trimmed) || /\.,/.test(trimmed)) return false;
+
+  const dotCount = (trimmed.match(/\./g) || []).length;
+  const commaCount = (trimmed.match(/,/g) || []).length;
+
+  if (dotCount > 1 && commaCount > 0) return false;
+
+  if (dotCount === 1 && commaCount === 1) {
+    const di = trimmed.indexOf('.');
+    const ci = trimmed.indexOf(',');
+    if (Math.abs(di - ci) === 1 || Math.abs(di - ci) === 2) {
+      const digitsBetweenSections = trimmed
+        .slice(Math.min(di, ci) + 1, Math.max(di, ci))
+        .replace(/[^0-9]/g, '');
+      if (digitsBetweenSections.length <= 1) return false;
+    }
+  }
+
+  const sanitized = sanitizeNumberInput(trimmed);
+  if (!sanitized) return false;
+  const value = parseFloat(sanitized);
   return Number.isFinite(value);
+}
+
+export function parseNumberInput(raw: string): number {
+  if (!raw || !raw.trim()) return 0;
+  if (!isValidNumberInput(raw)) return NaN;
+  const cleaned = sanitizeNumberInput(raw);
+  if (!cleaned) return NaN;
+  return parseFloat(cleaned);
 }
 
 export function formatNumberPtBR(value: number, decimals?: number): string {

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -15,7 +15,7 @@
  */
 
 export function sanitizeNumberInput(raw: string): string {
-  let cleaned = raw.replace(/[^0-9.,\-]/g, '');
+  let cleaned = raw.replace(/[^0-9.,-]/g, '');
   const negative = cleaned.startsWith('-');
   if (negative) cleaned = cleaned.slice(1);
 
@@ -95,7 +95,7 @@ export function isValidNumberInput(raw: string): boolean {
   if (!raw || !raw.trim()) return true;
   const trimmed = raw.trim();
 
-  if (/[^0-9.,\-]/.test(trimmed)) return false;
+  if (/[^0-9.,-]/.test(trimmed)) return false;
 
   const digitOnly = trimmed.replace(/[^0-9]/g, '');
   if (digitOnly.length === 0) return false;

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -71,11 +71,6 @@ export function sanitizeNumberInput(raw: string): string {
       return sign + cleaned.replace(/\./g, '');
     }
 
-    if (firstOk && middleOk && /^\d{0,3}$/.test(lastChunk) && lastChunk.length > 0) {
-      const whole = chunks.slice(0, -1).join('');
-      return sign + whole + '.' + lastChunk;
-    }
-
     return '';
   }
 

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -18,6 +18,7 @@ export function sanitizeNumberInput(raw: string): string {
   let cleaned = raw.replace(/[^0-9.,-]/g, '');
   const negative = cleaned.startsWith('-');
   if (negative) cleaned = cleaned.slice(1);
+  if (cleaned.includes('-')) return '';
 
   if (!cleaned) return '';
 
@@ -46,11 +47,7 @@ export function sanitizeNumberInput(raw: string): string {
 
   if (firstComma !== -1) {
     const count = (cleaned.match(/,/g) || []).length;
-    if (count > 1) {
-      const before = cleaned.slice(0, lastComma).replace(/,/g, '');
-      const after = cleaned.slice(lastComma + 1);
-      return sign + before + '.' + after;
-    }
+    if (count > 1) return '';
     const before = cleaned.slice(0, firstComma);
     const after = cleaned.slice(firstComma + 1);
     return sign + before + '.' + after;
@@ -84,7 +81,7 @@ export function sanitizeNumberInput(raw: string): string {
   const before = cleaned.slice(0, firstDot);
   const after = cleaned.slice(firstDot + 1);
 
-  if (after.length === 3 && before.length > 0 && /^\d+$/.test(before)) {
+  if (after.length === 3 && before.length > 0 && /^\d+$/.test(before) && before !== '0') {
     return sign + before + after;
   }
 
@@ -100,7 +97,8 @@ export function isValidNumberInput(raw: string): boolean {
   const digitOnly = trimmed.replace(/[^0-9]/g, '');
   if (digitOnly.length === 0) return false;
 
-  if (/^-.*-/.test(trimmed)) return false;
+  const minusCount = (trimmed.match(/-/g) || []).length;
+  if (minusCount > 1 || (minusCount === 1 && !trimmed.startsWith('-'))) return false;
 
   if (/\.\./.test(trimmed) || /,,/.test(trimmed)) return false;
 
@@ -110,6 +108,7 @@ export function isValidNumberInput(raw: string): boolean {
   const commaCount = (trimmed.match(/,/g) || []).length;
 
   if (dotCount > 1 && commaCount > 0) return false;
+  if (commaCount > 1 && dotCount === 0) return false;
 
   if (dotCount === 1 && commaCount === 1) {
     const di = trimmed.indexOf('.');

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -1,21 +1,117 @@
+/**
+ * pt-BR numeric input utilities.
+ *
+ * Handles the ambiguity between comma and dot as decimal separators
+ * in Brazilian Portuguese context. The canonical rule is:
+ * - "4,5" → 4.5  (comma = decimal, pt-BR convention)
+ * - "4.5" → 4.5  (dot = decimal, international convention)
+ * - "1.840" → 1840  (dot = thousands separator when followed by 3 digits)
+ * - "1,840" → 1.84  (comma = decimal, pt-BR convention)
+ * - "1,234.5" → 1234.5  (comma=thousands, dot=decimal — international)
+ * - "1.234,5" → 1234.5  (dot=thousands, comma=decimal — pt-BR)
+ * - Invalid: "1,2.3" → ambiguous (comma and dot too close, no clear grouping)
+ */
+
+export function sanitizeNumberInput(raw: string): string {
+  let cleaned = raw.replace(/[^0-9.,\-]/g, '');
+  const negative = cleaned.startsWith('-');
+  if (negative) cleaned = cleaned.slice(1);
+
+  if (!cleaned) return '';
+
+  const sign = negative ? '-' : '';
+
+  const firstComma = cleaned.indexOf(',');
+  const firstDot = cleaned.indexOf('.');
+  const lastComma = cleaned.lastIndexOf(',');
+  const lastDot = cleaned.lastIndexOf('.');
+
+  // No separators at all — plain integer
+  if (firstComma === -1 && firstDot === -1) {
+    return sign + cleaned;
+  }
+
+  // Both comma and dot present
+  if (firstComma !== -1 && firstDot !== -1) {
+    // Determine the decimal separator using the LAST separator:
+    if (lastComma > lastDot) {
+      // pt-BR: comma is decimal (1.234,5)
+      const afterComma = cleaned.slice(lastComma + 1);
+      const beforeComma = cleaned.slice(0, lastComma).replace(/\./g, '');
+      return sign + beforeComma + '.' + afterComma;
+    } else {
+      // International: dot is decimal (1,234.5)
+      // But first reject ambiguous inputs where comma appears in the decimal part
+      // e.g. "1,2.3" → comma at 1, dot at 3 → lastDot > lastComma → international
+      // But "1,2" as thousands before "3" decimal doesn't make sense
+      // Heuristic: if there's a comma between digits that are too close to the dot
+      // (comma has < 3 digits before next separator), it's likely invalid
+      const afterDot = cleaned.slice(lastDot + 1);
+      const beforeDot = cleaned.slice(0, lastDot).replace(/,/g, '');
+      return sign + beforeDot + '.' + afterDot;
+    }
+  }
+
+  // Only comma present
+  if (firstComma !== -1) {
+    const count = (cleaned.match(/,/g) || []).length;
+    if (count > 1) {
+      // Multiple commas: last comma is decimal, others are thousands separators
+      const before = cleaned.slice(0, lastComma).replace(/,/g, '');
+      const after = cleaned.slice(lastComma + 1);
+      return sign + before + '.' + after;
+    }
+    // Single comma: treat as decimal separator (pt-BR convention)
+    const before = cleaned.slice(0, firstComma);
+    const after = cleaned.slice(firstComma + 1);
+    return sign + before + '.' + after;
+  }
+
+  // Only dot present
+  const count = (cleaned.match(/\./g) || []).length;
+
+  if (count > 1) {
+    // Multiple dots: all are thousands separators (1.234.567)
+    const result = cleaned.replace(/\./g, '');
+    return sign + result;
+  }
+
+  // Single dot — could be decimal or thousands
+  // If exactly 3 digits after dot and digits before, treat as thousands: 1.840 → 1840
+  const before = cleaned.slice(0, firstDot);
+  const after = cleaned.slice(firstDot + 1);
+
+  if (after.length === 3 && before.length > 0 && /^\d+$/.test(before)) {
+    return sign + before + after;
+  }
+
+  // Otherwise, treat as decimal: 4.5 → 4.5
+  return sign + before + '.' + after;
+}
+
 export function parseNumberInput(raw: string): number {
+  if (!raw || !raw.trim()) return 0;
   const cleaned = sanitizeNumberInput(raw);
-  // Interpreta a primeira vírgula ou ponto como separador decimal
-  const normalized = cleaned.replace(/,/g, '.');
-  const value = parseFloat(normalized);
+  if (!cleaned) return NaN;
+  const value = parseFloat(cleaned);
   return isNaN(value) ? 0 : value;
 }
 
-export function sanitizeNumberInput(raw: string): string {
-  let cleaned = raw.replace(/[^0-9.,]/g, '');
-  const firstComma = cleaned.indexOf(',');
-  const firstDot = cleaned.indexOf('.');
-  const firstSep =
-    firstComma === -1 ? firstDot : firstDot === -1 ? firstComma : Math.min(firstComma, firstDot);
-  if (firstSep !== -1) {
-    const before = cleaned.slice(0, firstSep + 1);
-    const after = cleaned.slice(firstSep + 1).replace(/[.,]/g, '');
-    cleaned = before + after;
+export function isValidNumberInput(raw: string): boolean {
+  if (!raw || !raw.trim()) return true;
+  const cleaned = sanitizeNumberInput(raw);
+  if (!cleaned) return false;
+  const value = parseFloat(cleaned);
+  return Number.isFinite(value);
+}
+
+export function formatNumberPtBR(value: number, decimals?: number): string {
+  if (value == null || isNaN(value)) return '';
+  if (decimals !== undefined) {
+    return value.toLocaleString('pt-BR', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
   }
-  return cleaned;
+  return value.toLocaleString('pt-BR');
 }

--- a/frontend/src/utils/numberInput.ts
+++ b/frontend/src/utils/numberInput.ts
@@ -28,6 +28,8 @@ export function sanitizeNumberInput(raw: string): string {
   const lastComma = cleaned.lastIndexOf(',');
   const firstDot = cleaned.indexOf('.');
   const lastDot = cleaned.lastIndexOf('.');
+  const commaCount = (cleaned.match(/,/g) || []).length;
+  const dotCount = (cleaned.match(/\./g) || []).length;
 
   if (firstComma === -1 && firstDot === -1) {
     return sign + cleaned;
@@ -35,10 +37,12 @@ export function sanitizeNumberInput(raw: string): string {
 
   if (firstComma !== -1 && firstDot !== -1) {
     if (lastComma > lastDot) {
+      if (cleaned.slice(0, lastComma).includes(',')) return '';
       const afterComma = cleaned.slice(lastComma + 1);
       const beforeComma = cleaned.slice(0, lastComma).replace(/\./g, '');
       return sign + beforeComma + '.' + afterComma;
     } else {
+      if (cleaned.slice(0, lastDot).includes('.')) return '';
       const afterDot = cleaned.slice(lastDot + 1);
       const beforeDot = cleaned.slice(0, lastDot).replace(/,/g, '');
       return sign + beforeDot + '.' + afterDot;
@@ -46,14 +50,11 @@ export function sanitizeNumberInput(raw: string): string {
   }
 
   if (firstComma !== -1) {
-    const count = (cleaned.match(/,/g) || []).length;
-    if (count > 1) return '';
+    if (commaCount > 1) return '';
     const before = cleaned.slice(0, firstComma);
     const after = cleaned.slice(firstComma + 1);
     return sign + before + '.' + after;
   }
-
-  const dotCount = (cleaned.match(/\./g) || []).length;
 
   if (dotCount > 1) {
     const chunks = cleaned.split('.');

--- a/frontend/src/views/PlansView.tsx
+++ b/frontend/src/views/PlansView.tsx
@@ -343,23 +343,18 @@ export function PlansView({ patientId }: PlansViewProps) {
   };
 
   const handleSaveTargets = () => {
-    const kcal = parseNumberInput(targetValues.kcal);
-    const prot = parseNumberInput(targetValues.prot);
-    const carb = parseNumberInput(targetValues.carb);
-    const fat = parseNumberInput(targetValues.fat);
-    if (
-      Number.isFinite(kcal) &&
-      Number.isFinite(prot) &&
-      Number.isFinite(carb) &&
-      Number.isFinite(fat)
-    ) {
-      updatePlan.mutate({
-        kcalTarget: kcal,
-        protTarget: prot,
-        carbTarget: carb,
-        fatTarget: fat,
-      });
+    const parsedTargets = {
+      kcalTarget: parseNumberInput(targetValues.kcal),
+      protTarget: parseNumberInput(targetValues.prot),
+      carbTarget: parseNumberInput(targetValues.carb),
+      fatTarget: parseNumberInput(targetValues.fat),
+    };
+    const hasInvalidTarget = Object.values(parsedTargets).some((value) => !Number.isFinite(value));
+    if (hasInvalidTarget) {
+      return;
     }
+
+    updatePlan.mutate(parsedTargets);
     setEditingTargets(false);
   };
 

--- a/frontend/src/views/PlansView.tsx
+++ b/frontend/src/views/PlansView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { IconPlus, IconDownload, IconX, IconTrash, IconEdit } from '../components/icons';
+import { parseNumberInput } from '../utils/numberInput';
 import {
   PlanFoodRow,
   OptionTab,
@@ -342,10 +343,10 @@ export function PlansView({ patientId }: PlansViewProps) {
   };
 
   const handleSaveTargets = () => {
-    const kcal = Number(targetValues.kcal);
-    const prot = Number(targetValues.prot);
-    const carb = Number(targetValues.carb);
-    const fat = Number(targetValues.fat);
+    const kcal = parseNumberInput(targetValues.kcal);
+    const prot = parseNumberInput(targetValues.prot);
+    const carb = parseNumberInput(targetValues.carb);
+    const fat = parseNumberInput(targetValues.fat);
     if (
       Number.isFinite(kcal) &&
       Number.isFinite(prot) &&
@@ -538,7 +539,7 @@ export function PlansView({ patientId }: PlansViewProps) {
               <div style={{ display: 'flex', flexDirection: 'column', minWidth: 82 }}>
                 <div className="eyebrow">Kcal · meta</div>
                 <input
-                  type="number"
+                  inputMode="decimal"
                   autoFocus
                   value={targetValues.kcal}
                   onChange={(e) => setTargetValues((v) => ({ ...v, kcal: e.target.value }))}
@@ -563,7 +564,7 @@ export function PlansView({ patientId }: PlansViewProps) {
               <div style={{ display: 'flex', flexDirection: 'column', minWidth: 82 }}>
                 <div className="eyebrow">Proteína</div>
                 <input
-                  type="number"
+                  inputMode="decimal"
                   value={targetValues.prot}
                   onChange={(e) => setTargetValues((v) => ({ ...v, prot: e.target.value }))}
                   onKeyDown={(e) => {
@@ -587,7 +588,7 @@ export function PlansView({ patientId }: PlansViewProps) {
               <div style={{ display: 'flex', flexDirection: 'column', minWidth: 82 }}>
                 <div className="eyebrow">Carboidrato</div>
                 <input
-                  type="number"
+                  inputMode="decimal"
                   value={targetValues.carb}
                   onChange={(e) => setTargetValues((v) => ({ ...v, carb: e.target.value }))}
                   onKeyDown={(e) => {
@@ -611,7 +612,7 @@ export function PlansView({ patientId }: PlansViewProps) {
               <div style={{ display: 'flex', flexDirection: 'column', minWidth: 82 }}>
                 <div className="eyebrow">Gordura</div>
                 <input
-                  type="number"
+                  inputMode="decimal"
                   value={targetValues.fat}
                   onChange={(e) => setTargetValues((v) => ({ ...v, fat: e.target.value }))}
                   onKeyDown={(e) => {

--- a/frontend/src/views/PlansView.tsx
+++ b/frontend/src/views/PlansView.tsx
@@ -24,6 +24,7 @@ import {
   useUpdateExtra,
   useDeleteExtra,
 } from '../stores/planStore';
+import { useToastStore } from '../stores/toastStore';
 
 function DailyMacro({
   label,
@@ -351,6 +352,7 @@ export function PlansView({ patientId }: PlansViewProps) {
     };
     const hasInvalidTarget = Object.values(parsedTargets).some((value) => !Number.isFinite(value));
     if (hasInvalidTarget) {
+      useToastStore.getState().showError('Preencha metas numéricas válidas antes de salvar');
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Frontend**: Rewrote sanitizeNumberInput with last-separator heuristic for comma/dot ambiguity
- **Frontend**: Added isValidNumberInput and formatNumberPtBR utilities; updated parseNumberInput
- **Frontend**: Replaced all type=number inputs with inputMode=decimal across NewBiometryModal, EditPatientModal, and PlansView
- **Frontend**: Updated useValidation.ts and all form components to use parseNumberInput
- **Backend**: Added PtBRBigDecimalDeserializer in JacksonConfig.java with matching last-separator logic
- **Backend**: Fixed stripTrailingZeros scientific notation issue (e.g. 1840 -> 1.84E+3)
- **Tests**: 39 frontend + 14 backend unit tests covering edge cases

### Key design: last-separator rule

| Input | Result | Rationale |
|---|---|---|
| 4,5 | 4.5 | Single comma = decimal |
| 4.5 | 4.5 | Single dot = decimal |
| 1.840 | 1840 | Dot with 3 digits = thousands |
| 1,840 | 1.84 | Comma = decimal |
| 1.234,5 | 1234.5 | Last=comma: pt-BR |
| 1,234.5 | 1234.5 | Last=dot: international |
| 1,2.3 | 12.3 | Last=dot: international |

Closes LUC-40