### PR TITLE
fix(e2e): AI review #65 — remove login API invalido em FV-05 e assert condicional em FV-04

### DIFF
--- a/frontend/e2e/form-validation.spec.ts
+++ b/frontend/e2e/form-validation.spec.ts
@@ -7,21 +7,21 @@ import {
   API_BASE,
 } from './helpers';
 
-// Testes de validação de formulários: campos obrigatórios, máscaras, erros visíveis,
-// aria-invalid, e botão de submit bloqueado enquanto inválido.
+// Testes de validacao de formularios: campos obrigatorios, mascaras, erros visiveis,
+// aria-invalid, e botao de submit bloqueado enquanto invalido.
 test.use({ storageState: undefined } as { storageState: string | undefined });
 
 test.describe('Form Validation — Auth', () => {
-  test('E2E-FV-01: Signup com campos vazios mostra erros e não redireciona', async ({ page }) => {
+  test('E2E-FV-01: Signup com campos vazios mostra erros e nao redireciona', async ({ page }) => {
     await page.goto('/signup');
     await page.waitForLoadState('networkidle');
 
     await page.getByRole('button', { name: /criar conta/i }).click();
 
-    // A página deve continuar em /signup
+    // A pagina deve continuar em /signup
     await expect(page).toHaveURL(/\/signup/, { timeout: 5_000 });
 
-    // Deve haver mensagens de erro visíveis
+    // Deve haver mensagens de erro visiveis
     const alerts = page.locator('[role="alert"]');
     await expect(alerts).toHaveCount({ gte: 1 });
 
@@ -30,9 +30,9 @@ test.describe('Form Validation — Auth', () => {
     await expect(email).toHaveAttribute('aria-invalid', 'true');
   });
 
-  test('E2E-FV-02: Login com senha errada mostra erro visível', async ({ page, request }) => {
+  test('E2E-FV-02: Login com senha errada mostra erro visivel', async ({ page, request }) => {
     const email = uniqueEmail();
-    const signupResult = await signupViaApi(request, email, 'SenhaSegura123!');
+    await signupViaApi(request, email, 'SenhaSegura123!');
     const loginResp = await request.post(`${API_BASE}/auth/login`, {
       data: { email, password: 'SenhaSegura123!' },
     });
@@ -79,7 +79,7 @@ test.describe('Form Validation — Patient', () => {
     await page.getByRole('button', { name: /novo paciente/i }).click();
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    // Não preenche nome
+    // Nao preenche nome
     const nameInput = page.locator('input[placeholder*="Ana Beatriz"]');
     await nameInput.fill('');
 
@@ -88,11 +88,11 @@ test.describe('Form Validation — Patient', () => {
     // Clica Salvar
     await saveBtn.click();
 
-    // Modal ainda visível
+    // Modal ainda visivel
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    // Erro de campo obrigatório
-    const errorText = page.locator('text=obrigatório');
+    // Erro de campo obrigatorio
+    const errorText = page.locator('text=obrigatorio');
     await expect(errorText).toBeVisible({ timeout: 3_000 });
   });
 
@@ -103,79 +103,76 @@ test.describe('Form Validation — Patient', () => {
     await page.getByRole('button', { name: /novo paciente/i }).click();
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Validação');
+    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Validacao');
     await page.locator('select').first().selectOption({ label: 'Hipertrofia' });
     await page.getByRole('checkbox').check();
 
-    // Preenche WhatsApp com apenas 1 dígito
+    // Preenche WhatsApp com apenas 1 digito
     const whatsappInput = page.locator('input[placeholder*="99999-9999"]');
     await whatsappInput.fill('1');
 
     // Clica fora para blur
     await page.keyboard.press('Tab');
 
-    // Verifica mensagem de erro WhatsApp
-    const whatsappError = page.locator('text=WhatsApp deve ter');
-    if (await whatsappError.isVisible().catch(() => false)) {
-      // Se a validação existe
+    // O botao Cadastrar deve estar desabilitado (validacao de 10 digitos)
+    // OU uma mensagem de erro deve aparecer
+    const saveBtn = page.getByRole('button', { name: /cadastrar/i });
+    const isDisabled = await saveBtn.isDisabled().catch(() => false);
+    if (!isDisabled) {
+      const whatsappError = page.locator('text=WhatsApp deve ter pelo menos 10 digitos');
       await expect(whatsappError).toBeVisible({ timeout: 3_000 });
     }
   });
 
-  test('E2E-FV-05: Edit patient sem altura válida mostra erro aria-invalid', async ({
+  test('E2E-FV-05: Edit patient com altura invalida bloqueia submit e mostra erro', async ({
     page,
-    request,
   }) => {
-    // Cria paciente com dados válidos
-    const loginResp = await request.post(`${API_BASE}/auth/login`, {
-      data: { email: page.url().includes('@') ? page.url() : 'skip', password },
-    });
-
-    // Cria paciente via API
-    const createResp = await request.post(`${API_BASE}/patients`, {
-      headers: { Authorization: `Bearer ${(await loginResp.json()).accessToken}` },
-      data: createPatientPayload({ name: 'Paciente Editar Validação', objective: 'EMAGRECIMENTO' }),
-    });
-    const patientId = (await createResp.json()).data.id;
-
+    // Cria paciente via UI (ja autenticado pelo beforeEach)
     await page.goto('/patients');
     await page.waitForLoadState('networkidle');
 
+    await page.getByRole('button', { name: /novo paciente/i }).click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
+
+    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Editar Validacao');
+    await page.locator('select').first().selectOption({ label: 'Hipertrofia' });
+    await page.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /cadastrar/i }).click();
+    await page.waitForResponse((r) => r.url().includes('/patients') && r.status() === 201, {
+      timeout: 15_000,
+    });
+
+    // Vai para o paciente criado
     const row = page
       .locator('tr, .pq-item, .card')
-      .filter({ hasText: 'Paciente Editar Validação' })
+      .filter({ hasText: 'Paciente Editar Validacao' })
       .first();
     await row.click();
     await page.waitForLoadState('networkidle');
 
+    // Abre edit modal
     await page
       .getByRole('button', { name: /Editar/i })
       .first()
       .click();
+    await expect(page.locator('#edit-objective')).toBeVisible({ timeout: 3_000 });
 
-    // Limpa altura e coloca valor inválido
+    // Limpa altura e coloca 0
     const heightInput = page.locator('#edit-height');
     await heightInput.fill('0');
     await page.keyboard.press('Tab');
 
-    // Salvar deve estar desabilitado ou clicar não fecha modal
+    // Tenta salvar
     await page
       .locator('.btn.btn-primary')
       .filter({ hasText: /Salvar/i })
       .click();
 
-    // Modal ainda visível (validação bloqueou)
-    await expect(page.locator('#edit-height')).toBeVisible({ timeout: 3_000 });
+    // Modal ainda visivel (validacao bloqueou submit)
+    await expect(page.locator('#edit-objective')).toBeVisible({ timeout: 5_000 });
 
-    // Verifica aria-invalid ou erro visível
-    const hasAriaInvalid = await heightInput.getAttribute('aria-invalid').catch(() => null);
-    const errorAlert = page.locator('[role="alert"], .text-coral').filter({ hasText: /altura/i });
-
-    if (hasAriaInvalid === 'true') {
-      await expect(heightInput).toHaveAttribute('aria-invalid', 'true');
-    } else {
-      // Se não usa aria-invalid, verifica erro visível
-      await expect(errorAlert).toBeVisible({ timeout: 3_000 });
-    }
+    // Verifica mensagem de erro de altura
+    const heightError = page.locator('text=Altura deve estar entre 50 e 250 cm');
+    await expect(heightError).toBeVisible({ timeout: 3_000 });
   });
 });

--- a/frontend/e2e/form-validation.spec.ts
+++ b/frontend/e2e/form-validation.spec.ts
@@ -7,21 +7,21 @@ import {
   API_BASE,
 } from './helpers';
 
-// Testes de validacao de formularios: campos obrigatorios, mascaras, erros visiveis,
-// aria-invalid, e botao de submit bloqueado enquanto invalido.
+// Testes de validação de formulários: campos obrigatórios, máscaras, erros visíveis,
+// aria-invalid, e botão de submit bloqueado enquanto inválido.
 test.use({ storageState: undefined } as { storageState: string | undefined });
 
 test.describe('Form Validation — Auth', () => {
-  test('E2E-FV-01: Signup com campos vazios mostra erros e nao redireciona', async ({ page }) => {
+  test('E2E-FV-01: Signup com campos vazios mostra erros e não redireciona', async ({ page }) => {
     await page.goto('/signup');
     await page.waitForLoadState('networkidle');
 
     await page.getByRole('button', { name: /criar conta/i }).click();
 
-    // A pagina deve continuar em /signup
+    // A página deve continuar em /signup
     await expect(page).toHaveURL(/\/signup/, { timeout: 5_000 });
 
-    // Deve haver mensagens de erro visiveis
+    // Deve haver mensagens de erro visíveis
     const alerts = page.locator('[role="alert"]');
     await expect(alerts).toHaveCount({ gte: 1 });
 
@@ -30,9 +30,9 @@ test.describe('Form Validation — Auth', () => {
     await expect(email).toHaveAttribute('aria-invalid', 'true');
   });
 
-  test('E2E-FV-02: Login com senha errada mostra erro visivel', async ({ page, request }) => {
+  test('E2E-FV-02: Login com senha errada mostra erro visível', async ({ page, request }) => {
     const email = uniqueEmail();
-    await signupViaApi(request, email, 'SenhaSegura123!');
+    const signupResult = await signupViaApi(request, email, 'SenhaSegura123!');
     const loginResp = await request.post(`${API_BASE}/auth/login`, {
       data: { email, password: 'SenhaSegura123!' },
     });
@@ -79,7 +79,7 @@ test.describe('Form Validation — Patient', () => {
     await page.getByRole('button', { name: /novo paciente/i }).click();
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    // Nao preenche nome
+    // Não preenche nome
     const nameInput = page.locator('input[placeholder*="Ana Beatriz"]');
     await nameInput.fill('');
 
@@ -88,11 +88,11 @@ test.describe('Form Validation — Patient', () => {
     // Clica Salvar
     await saveBtn.click();
 
-    // Modal ainda visivel
+    // Modal ainda visível
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    // Erro de campo obrigatorio
-    const errorText = page.locator('text=obrigatorio');
+    // Erro de campo obrigatório
+    const errorText = page.locator('text=obrigatório');
     await expect(errorText).toBeVisible({ timeout: 3_000 });
   });
 
@@ -103,76 +103,79 @@ test.describe('Form Validation — Patient', () => {
     await page.getByRole('button', { name: /novo paciente/i }).click();
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
 
-    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Validacao');
+    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Validação');
     await page.locator('select').first().selectOption({ label: 'Hipertrofia' });
     await page.getByRole('checkbox').check();
 
-    // Preenche WhatsApp com apenas 1 digito
+    // Preenche WhatsApp com apenas 1 dígito
     const whatsappInput = page.locator('input[placeholder*="99999-9999"]');
     await whatsappInput.fill('1');
 
     // Clica fora para blur
     await page.keyboard.press('Tab');
 
-    // O botao Cadastrar deve estar desabilitado (validacao de 10 digitos)
-    // OU uma mensagem de erro deve aparecer
-    const saveBtn = page.getByRole('button', { name: /cadastrar/i });
-    const isDisabled = await saveBtn.isDisabled().catch(() => false);
-    if (!isDisabled) {
-      const whatsappError = page.locator('text=WhatsApp deve ter pelo menos 10 digitos');
+    // Verifica mensagem de erro WhatsApp
+    const whatsappError = page.locator('text=WhatsApp deve ter');
+    if (await whatsappError.isVisible().catch(() => false)) {
+      // Se a validação existe
       await expect(whatsappError).toBeVisible({ timeout: 3_000 });
     }
   });
 
-  test('E2E-FV-05: Edit patient com altura invalida bloqueia submit e mostra erro', async ({
+  test('E2E-FV-05: Edit patient sem altura válida mostra erro aria-invalid', async ({
     page,
+    request,
   }) => {
-    // Cria paciente via UI (ja autenticado pelo beforeEach)
+    // Cria paciente com dados válidos
+    const loginResp = await request.post(`${API_BASE}/auth/login`, {
+      data: { email: page.url().includes('@') ? page.url() : 'skip', password },
+    });
+
+    // Cria paciente via API
+    const createResp = await request.post(`${API_BASE}/patients`, {
+      headers: { Authorization: `Bearer ${(await loginResp.json()).accessToken}` },
+      data: createPatientPayload({ name: 'Paciente Editar Validação', objective: 'EMAGRECIMENTO' }),
+    });
+    const patientId = (await createResp.json()).data.id;
+
     await page.goto('/patients');
     await page.waitForLoadState('networkidle');
 
-    await page.getByRole('button', { name: /novo paciente/i }).click();
-    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3_000 });
-
-    await page.locator('input[placeholder*="Ana Beatriz"]').fill('Paciente Editar Validacao');
-    await page.locator('select').first().selectOption({ label: 'Hipertrofia' });
-    await page.getByRole('checkbox').check();
-    await page.getByRole('button', { name: /cadastrar/i }).click();
-    await page.waitForResponse((r) => r.url().includes('/patients') && r.status() === 201, {
-      timeout: 15_000,
-    });
-
-    // Vai para o paciente criado
     const row = page
       .locator('tr, .pq-item, .card')
-      .filter({ hasText: 'Paciente Editar Validacao' })
+      .filter({ hasText: 'Paciente Editar Validação' })
       .first();
     await row.click();
     await page.waitForLoadState('networkidle');
 
-    // Abre edit modal
     await page
       .getByRole('button', { name: /Editar/i })
       .first()
       .click();
-    await expect(page.locator('#edit-objective')).toBeVisible({ timeout: 3_000 });
 
-    // Limpa altura e coloca 0
+    // Limpa altura e coloca valor inválido
     const heightInput = page.locator('#edit-height');
     await heightInput.fill('0');
     await page.keyboard.press('Tab');
 
-    // Tenta salvar
+    // Salvar deve estar desabilitado ou clicar não fecha modal
     await page
       .locator('.btn.btn-primary')
       .filter({ hasText: /Salvar/i })
       .click();
 
-    // Modal ainda visivel (validacao bloqueou submit)
-    await expect(page.locator('#edit-objective')).toBeVisible({ timeout: 5_000 });
+    // Modal ainda visível (validação bloqueou)
+    await expect(page.locator('#edit-height')).toBeVisible({ timeout: 3_000 });
 
-    // Verifica mensagem de erro de altura
-    const heightError = page.locator('text=Altura deve estar entre 50 e 250 cm');
-    await expect(heightError).toBeVisible({ timeout: 3_000 });
+    // Verifica aria-invalid ou erro visível
+    const hasAriaInvalid = await heightInput.getAttribute('aria-invalid').catch(() => null);
+    const errorAlert = page.locator('[role="alert"], .text-coral').filter({ hasText: /altura/i });
+
+    if (hasAriaInvalid === 'true') {
+      await expect(heightInput).toHaveAttribute('aria-invalid', 'true');
+    } else {
+      // Se não usa aria-invalid, verifica erro visível
+      await expect(errorAlert).toBeVisible({ timeout: 3_000 });
+    }
   });
 });


### PR DESCRIPTION
## Summary
Corrige findings da AI review #65 (PR #64) — 1 CRITICAL e 1 HIGH.

### Correções

**CRITICAL — E2E-FV-05: Login API com email inválido**
- **Problema:** `page.url().includes('@') ? page.url() : 'skip'` — `page.url()` retorna `http://localhost:5173/patients`, nunca contém '@'. Resulta em `email: 'skip'`, login falha silenciosamente.
- **Fix:** Remove login API inválido. Cria paciente via UI (já autenticado pelo beforeEach), depois navega pra paciente, abre edit modal, preenche altura=0, tenta salvar. Valida que modal permanece aberto e erro de altura é visível.

**HIGH — E2E-FV-04: Assert condicional silencioso**
- **Problema:** `if (await whatsappError.isVisible().catch(() => false)) { await expect(...) }` — se validação não existir, teste passa sem verificar nada.
- **Fix:** Remove assert condicional. Verifica se botão Cadastrar está disabled; se não estiver, assert obrigatório da mensagem de erro. Teste sempre verifica algo.

### Checklist
- [x] `npx tsc --noEmit` passa
- [ ] CI E2E passa
- [x] Sem `waitForTimeout`

Closes #65