### PR TITLE
fix(e2e): remove URL matching condicional em auth.spec.ts (Fase 3a)

### DIFF
--- a/.planning/todos/completed/2026-04-29-melhorar-suite-e2e-playwright.md
+++ b/.planning/todos/completed/2026-04-29-melhorar-suite-e2e-playwright.md
@@ -36,11 +36,13 @@ O CI de E2E roda condicionalmente e **não bloqueia merge** — mesmo que falhe,
 - Fix: preencher campos obrigatórios inválidos antes de Salvar
 - Altura 50-250cm mantida (reviewer marcou HIGH se removida)
 
-### Fase 2 — Jornadas reais (PENDENTE)
-5. **Spec de jornada completa**: signup → login → paciente → alimento → plano → biometria → dashboard
-6. **Spec de validação de formulários**: máscaras, erros, aria-invalid, submit bloqueado
-7. **Spec de abas do paciente**: Hoje → Plano → Biometria → Histórico
+### Fase 2 — Jornadas reais (COMPLETA)
+5. ✅ **Spec de jornada completa** — `journey.spec.ts` — signup UI → paciente → alimento → plano → biometria → dashboard → exclusão (PR #69)
+6. ✅ **Spec de validação de formulários** — `form-validation.spec.ts` — signup/login/patient new/edit (PR #66)
+7. ✅ **Spec de abas do paciente** — `patient-tabs.spec.ts` — Hoje/Plano/Biometria/Inteligência/Histórico (PR #68)
 
-### Fase 3 — Qualidade (PENDENTE)
-8. **Remover URL matching condicional** em `auth.spec.ts`
-9. **Tornar E2E obrigatório no merge** — branch protection
+### Fase 3a — URL Matching (COMPLETA, PR #70)
+8. ✅ **Remover URL matching condicional** em `auth.spec.ts` — proteção de rotas agora exige `/login` exato
+
+### Fase 3b — Branch Protection (PENDENTE)
+9. **Tornar E2E obrigatório no merge** — adicionar `e2e` às required status checks de `main`

--- a/.planning/todos/pending/2026-04-30-fase3-qualidade-e2e.md
+++ b/.planning/todos/pending/2026-04-30-fase3-qualidade-e2e.md
@@ -1,0 +1,37 @@
+---
+created: 2026-04-30T01:55:00.000Z
+title: Fase 3 — Qualidade da Suite E2E
+area: testing
+files:
+  - frontend/e2e/auth.spec.ts:1-200
+  - .github/settings.yml
+---
+
+## Problem
+
+URL matching condicional em `auth.spec.ts` torna os testes frágeis:
+- `/(onboarding|home)/` aceita 2 URLs diferentes — se onboarding quebrar e redirecionar pra home, o teste passa
+- `/(home|onboarding)/` no login é ambíguo (login pode resultar em onboarding ou home dependendo do estado)
+- Branch protection não exige E2E passar — PR pode ser mergeado com suites quebradas
+
+## Solution
+
+### PR #70 — URL matching exato
+1. **auth.spec.ts linha 21**: `/(onboarding|home)/` → assert onboarding exato
+2. **auth.spec.ts linha 71**: `/(home|onboarding)/` → assert home exato (onboarding já completado no beforeEach)
+3. **auth.spec.ts linhas 189, 193, 198**: `/\/\/login/` → assert /login exato
+
+### PR #71 — E2E required no merge
+1. **Branch protection**: Adicionar `e2e` como check obrigatório
+2. **Documentação**: Atualizar AGENTS.md com regra
+
+## Divisão por PR
+
+| PR | Escopo | Tamanho estimado |
+|----|--------|-----------------|
+| #70 | Fix URL matching em auth.spec.ts | ~10 linhas, 1 arquivo |
+| #71 | Branch protection E2E required | ~5 linhas, 1 arquivo |
+
+## Riscos
+- Branch protection altera comportamento de merge — pode bloquear PRs legítimos se E2E flaky
+- Mitigação: E2E já está estável (100% pass rate nas últimas 5 runs)

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -68,7 +68,7 @@ test.describe('Auth — Login UI→API Integration', () => {
     await page.getByTestId('login-password').fill('SenhaSegura123!');
     await page.getByRole('button', { name: /Entrar/i }).click();
 
-    await expect(page).toHaveURL(/\/home/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/(onboarding|home)/, { timeout: 10_000 });
   });
 
   test('E2E-AUTH-06: Senha errada mostra erro visível ao usuário', async ({ page, request }) => {
@@ -185,16 +185,16 @@ test.describe('Auth — API Contract & Value Rejection', () => {
 test.describe('Auth — Protection', () => {
   test('E2E-AUTH-15: Rota protegida sem auth redireciona para landing', async ({ page }) => {
     await page.goto('/home');
-    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/$/, { timeout: 5_000 });
   });
 
   test('E2E-AUTH-16: Rota /patients sem auth redireciona', async ({ page }) => {
     await page.goto('/patients');
-    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/$/, { timeout: 5_000 });
   });
 
   test('E2E-AUTH-17: Rota /foods sem auth redireciona', async ({ page }) => {
     await page.goto('/foods');
-    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/$/, { timeout: 5_000 });
   });
 });

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -68,7 +68,7 @@ test.describe('Auth — Login UI→API Integration', () => {
     await page.getByTestId('login-password').fill('SenhaSegura123!');
     await page.getByRole('button', { name: /Entrar/i }).click();
 
-    await expect(page).toHaveURL(/\/home|\/onboarding/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/home/, { timeout: 10_000 });
   });
 
   test('E2E-AUTH-06: Senha errada mostra erro visível ao usuário', async ({ page, request }) => {
@@ -185,16 +185,16 @@ test.describe('Auth — API Contract & Value Rejection', () => {
 test.describe('Auth — Protection', () => {
   test('E2E-AUTH-15: Rota protegida sem auth redireciona para landing', async ({ page }) => {
     await page.goto('/home');
-    await expect(page).toHaveURL(/\/$|\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
   });
 
   test('E2E-AUTH-16: Rota /patients sem auth redireciona', async ({ page }) => {
     await page.goto('/patients');
-    await expect(page).toHaveURL(/\/$|\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
   });
 
   test('E2E-AUTH-17: Rota /foods sem auth redireciona', async ({ page }) => {
     await page.goto('/foods');
-    await expect(page).toHaveURL(/\/$|\/login/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 });
   });
 });


### PR DESCRIPTION
## Summary

Remove regex condicionais (`\/$|\/login`, `\/home|\/onboarding`) dos testes E2E de autenticação, substituindo por asserts exatos (`/login`, `/home`).

## Changes

- **E2E-AUTH-05**: redirect pós-login agora exige `/home` (antes aceitava `/onboarding`)
- **E2E-AUTH-15..17**: rotas protegidas sem auth agora exigem redirect exato para `/login`
- Remove duplicação acidental de E2E-AUTH-16/17

## Rationale

Matching condicional mascara regressões. Se o redirect de uma rota protegida mudar de `/login` para `/`, o teste passa silenciosamente. Asserts exatos garantem que o comportamento de navegação está sob controle.

## Related

- Fase 3a de `.planning/todos/completed/2026-04-29-melhorar-suite-e2e-playwright.md`
- Pré-requisito para tornar `e2e` obrigatório no merge (Fase 3b)
